### PR TITLE
feat(core): add recording and replaying indicators, avoid replaying while recording and vice versa, move keypad events to its own reducer as it has grown too big

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - feat(ip): use pythonping to perform a real ping test instead to determine the internet connection status instead of opening a socket
 - feat(core): user can start/end recording actioning by hitting r, actions will be recorded in `recordings/` directory and the last recording can be replayed by hitting `ctrl+r` - closes #187
 - feat(core): use new `SpinnerWidget` of ubo-gui to show unknown progress in notifications, and add `General` sub menu to `System` settings menu to host ubo-pod/ubo-app related settings, currently it has `Debug` toggle to control a debug feature of `HeadlessWidget` - closes #190
+- feat(core): add recording and replaying indicators, avoid replaying while recording and vice versa, move keypad events to its own reducer as it has grown too big
 
 ## Version 1.0.0
 

--- a/tests/integration/results/test_core/app_runs_and_exits/store-desktop-000.jsonc
+++ b/tests/integration/results/test_core/app_runs_and_exits/store-desktop-000.jsonc
@@ -9,6 +9,7 @@
     "is_footer_visible": true,
     "is_header_visible": true,
     "is_recording": false,
+    "is_replaying": false,
     "menu": {
       "_type": "HeadlessMenu",
       "items": [

--- a/tests/integration/results/test_core/app_runs_and_exits/store-rpi-000.jsonc
+++ b/tests/integration/results/test_core/app_runs_and_exits/store-rpi-000.jsonc
@@ -9,6 +9,7 @@
     "is_footer_visible": true,
     "is_header_visible": true,
     "is_recording": false,
+    "is_replaying": false,
     "menu": {
       "_type": "HeadlessMenu",
       "items": [

--- a/tests/integration/results/test_services/all_services_register/store-desktop-000.jsonc
+++ b/tests/integration/results/test_services/all_services_register/store-desktop-000.jsonc
@@ -98,6 +98,10 @@
     ],
     "is_connected": true
   },
+  "keypad": {
+    "_type": "KeypadState",
+    "depth": 1
+  },
   "lightdm": {
     "_type": "LightDMState",
     "is_active": true,
@@ -111,6 +115,7 @@
     "is_footer_visible": true,
     "is_header_visible": true,
     "is_recording": false,
+    "is_replaying": false,
     "menu": {
       "_type": "HeadlessMenu",
       "items": [

--- a/tests/integration/results/test_services/all_services_register/store-rpi-000.jsonc
+++ b/tests/integration/results/test_services/all_services_register/store-rpi-000.jsonc
@@ -98,6 +98,10 @@
     ],
     "is_connected": true
   },
+  "keypad": {
+    "_type": "KeypadState",
+    "depth": 1
+  },
   "lightdm": {
     "_type": "LightDMState",
     "is_active": false,
@@ -111,6 +115,7 @@
     "is_footer_visible": true,
     "is_header_visible": true,
     "is_recording": false,
+    "is_replaying": false,
     "menu": {
       "_type": "HeadlessMenu",
       "items": [

--- a/ubo_app/main.py
+++ b/ubo_app/main.py
@@ -10,6 +10,7 @@ import dotenv
 from ubo_app.error_handlers import setup_error_handling
 from ubo_app.logging import setup_logging
 from ubo_app.setup import setup
+from ubo_app.utils import IS_RPI
 
 dotenv.load_dotenv(Path(__file__).parent / '.dev.env')
 dotenv.load_dotenv(Path(__file__).parent / '.env')
@@ -55,7 +56,7 @@ def main() -> None:
 
     headless_kivy.config.setup_headless_kivy(
         headless_kivy.config.SetupHeadlessConfig(
-            bandwidth_limit=70 * 1000 * 1000 // 8 // 2,
+            bandwidth_limit=70 * 1000 * 1000 // 8 // 2 if IS_RPI else 0,
             bandwidth_limit_window=0.03,
             bandwidth_limit_overhead=10000,
             region_size=60,

--- a/ubo_app/services/000-keypad/reducer.py
+++ b/ubo_app/services/000-keypad/reducer.py
@@ -1,0 +1,190 @@
+"""Keypad reducer."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from redux import (
+    CombineReducerInitAction,
+    CompleteReducerResult,
+    FinishEvent,
+    InitializationActionError,
+    ReducerResult,
+)
+
+from ubo_app.store.core.types import (
+    MainEvent,
+    MenuChooseByIndexEvent,
+    MenuEvent,
+    MenuGoBackEvent,
+    MenuGoHomeEvent,
+    MenuScrollDirection,
+    MenuScrollEvent,
+    ReplayRecordedSequenceAction,
+    ScreenshotEvent,
+    SetMenuPathAction,
+    SnapshotEvent,
+    ToggleRecordingAction,
+)
+from ubo_app.store.services.audio import AudioChangeVolumeAction, AudioDevice
+from ubo_app.store.services.keypad import (
+    Key,
+    KeypadAction,
+    KeypadKeyPressAction,
+    KeypadKeyReleaseAction,
+    KeypadState,
+)
+from ubo_app.store.services.notifications import Notification, NotificationsAddAction
+
+if TYPE_CHECKING:
+    from ubo_app.store.services.audio import AudioAction
+
+
+def reducer(
+    state: KeypadState | None,
+    action: KeypadAction,
+) -> (
+    ReducerResult[
+        KeypadState,
+        AudioAction
+        | NotificationsAddAction
+        | ToggleRecordingAction
+        | ReplayRecordedSequenceAction,
+        FinishEvent | MenuEvent | MainEvent,
+    ]
+    | None
+):
+    """Keypad reducer."""
+    if state is None:
+        if isinstance(action, CombineReducerInitAction):
+            return KeypadState()
+
+        raise InitializationActionError(action)
+
+    if isinstance(action, KeypadKeyPressAction):
+        if action.pressed_keys == {action.key}:
+            if action.key == Key.UP and state.depth == 1:
+                return CompleteReducerResult(
+                    state=state,
+                    actions=[
+                        AudioChangeVolumeAction(
+                            amount=0.05,
+                            device=AudioDevice.OUTPUT,
+                        ),
+                    ],
+                )
+            if action.key == Key.DOWN and state.depth == 1:
+                return CompleteReducerResult(
+                    state=state,
+                    actions=[
+                        AudioChangeVolumeAction(
+                            amount=-0.05,
+                            device=AudioDevice.OUTPUT,
+                        ),
+                    ],
+                )
+
+            if action.key == Key.L1:
+                return CompleteReducerResult(
+                    state=state,
+                    events=[MenuChooseByIndexEvent(index=0)],
+                )
+            if action.key == Key.L2:
+                return CompleteReducerResult(
+                    state=state,
+                    events=[MenuChooseByIndexEvent(index=1)],
+                )
+            if action.key == Key.L3:
+                return CompleteReducerResult(
+                    state=state,
+                    events=[MenuChooseByIndexEvent(index=2)],
+                )
+            if action.key == Key.UP:
+                return CompleteReducerResult(
+                    state=state,
+                    events=[MenuScrollEvent(direction=MenuScrollDirection.UP)],
+                )
+            if action.key == Key.DOWN:
+                return CompleteReducerResult(
+                    state=state,
+                    events=[MenuScrollEvent(direction=MenuScrollDirection.DOWN)],
+                )
+        else:
+            if action.pressed_keys == {Key.HOME, Key.L1} and action.key == Key.L1:
+                return CompleteReducerResult(
+                    state=state,
+                    events=[ScreenshotEvent()],
+                )
+            if action.pressed_keys == {Key.HOME, Key.L2} and action.key == Key.L2:
+                return CompleteReducerResult(
+                    state=state,
+                    events=[SnapshotEvent()],
+                )
+            if action.pressed_keys == {Key.HOME, Key.L3} and action.key == Key.L3:
+                return CompleteReducerResult(
+                    state=state,
+                    actions=[ToggleRecordingAction()],
+                )
+            if action.pressed_keys == {Key.BACK, Key.L3} and action.key == Key.L3:
+                return CompleteReducerResult(
+                    state=state,
+                    actions=[ReplayRecordedSequenceAction()],
+                )
+            if action.pressed_keys == {Key.HOME, Key.BACK} and action.key == Key.BACK:
+                return CompleteReducerResult(
+                    state=state,
+                    events=[FinishEvent()],
+                )
+
+            # DEMO {
+            if action.pressed_keys == {Key.HOME, Key.UP} and action.key == Key.UP:
+                return CompleteReducerResult(
+                    state=state,
+                    actions=[
+                        NotificationsAddAction(
+                            notification=Notification(
+                                title='Test notification with progress',
+                                content='This is a test notification with progress',
+                                progress=0.5,
+                            ),
+                        ),
+                    ],
+                )
+            if action.pressed_keys == {Key.HOME, Key.DOWN} and action.key == Key.DOWN:
+                return CompleteReducerResult(
+                    state=state,
+                    actions=[
+                        NotificationsAddAction(
+                            notification=Notification(
+                                icon='',
+                                title='Test notification with spinner',
+                                content='This is a test notification with spinner',
+                                progress=math.nan,
+                            ),
+                        ),
+                    ],
+                )
+            # DEMO }
+        return state
+
+    if isinstance(action, KeypadKeyReleaseAction):
+        if len(action.pressed_keys) == 0:
+            if action.key == Key.BACK:
+                return CompleteReducerResult(
+                    state=state,
+                    events=[MenuGoBackEvent()],
+                )
+            if action.key == Key.HOME:
+                return CompleteReducerResult(
+                    state=state,
+                    events=[MenuGoHomeEvent()],
+                )
+
+        return state
+
+    if isinstance(action, SetMenuPathAction):
+        return replace(state, depth=action.depth)
+
+    return state

--- a/ubo_app/services/000-keypad/ubo_handle.py
+++ b/ubo_app/services/000-keypad/ubo_handle.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ubo_handle import register
+    from ubo_handle import Service, register
 
 
-def setup() -> None:
+def setup(service: Service) -> None:
+    from reducer import reducer
     from setup import init_service
 
+    service.register_reducer(reducer)
     init_service()
 
 

--- a/ubo_app/side_effects.py
+++ b/ubo_app/side_effects.py
@@ -8,6 +8,7 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import numpy as np
 from redux import FinishAction, FinishEvent
 
 from ubo_app import display
@@ -72,6 +73,8 @@ def write_image(image_path: Path, array: NDArray) -> None:
     """Write the `NDAarray` as an image to the given path."""
     import png
 
+    array = np.flipud(array)
+
     png.Writer(
         alpha=True,
         width=array.shape[0],
@@ -129,9 +132,9 @@ def store_recorded_sequence(event: StoreRecordedSequenceEvent) -> None:
         file.write(json_dump)
 
 
-def replay_recorded_sequence() -> None:
+async def replay_recorded_sequence() -> None:
     """Replay the recorded sequence."""
-    replay_actions(store, Path('recordings/active.json'))
+    await replay_actions(store, Path('recordings/active.json'))
 
 
 def setup_side_effects() -> None:

--- a/ubo_app/store/core/types.py
+++ b/ubo_app/store/core/types.py
@@ -174,14 +174,26 @@ class SnapshotEvent(MainEvent):
     """Event for taking a snapshot of the store."""
 
 
+class ToggleRecordingAction(MainAction):
+    """Action for toggling recording."""
+
+
 class StoreRecordedSequenceEvent(MainEvent):
     """Event for storing a recorded sequence."""
 
     recorded_sequence: list[BaseAction]
 
 
+class ReplayRecordedSequenceAction(MainAction):
+    """Action for replaying a recorded sequence."""
+
+
 class ReplayRecordedSequenceEvent(MainEvent):
     """Event for replaying a recorded sequence."""
+
+
+class ReportReplayingDoneAction(MainAction):
+    """Action for reporting that replaying is done."""
 
 
 class MainState(Immutable):
@@ -192,4 +204,5 @@ class MainState(Immutable):
     is_footer_visible: bool = True
     settings_items_priorities: dict[str, int] = field(default_factory=dict)
     is_recording: bool = False
+    is_replaying: bool = False
     recorded_sequence: list[BaseAction] = field(default_factory=list)

--- a/ubo_app/store/services/keypad.py
+++ b/ubo_app/store/services/keypad.py
@@ -5,6 +5,7 @@ import time
 from dataclasses import field
 from enum import StrEnum
 
+from immutable import Immutable
 from redux import BaseAction
 
 
@@ -34,3 +35,7 @@ class KeypadKeyPressAction(KeypadAction): ...
 
 
 class KeypadKeyReleaseAction(KeypadAction): ...
+
+
+class KeypadState(Immutable):
+    depth: int = 0

--- a/ubo_app/utils/store.py
+++ b/ubo_app/utils/store.py
@@ -1,9 +1,11 @@
 # ruff: noqa: D100, D101, D102, D103, D104, D107
 from __future__ import annotations
 
+import asyncio
 import json
-import time
 from typing import TYPE_CHECKING, Any, cast
+
+from ubo_app.store.core.types import ReportReplayingDoneAction
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -11,10 +13,12 @@ if TYPE_CHECKING:
     from ubo_app.store.main import UboStore
 
 
-def replay_actions(store: UboStore, path: Path) -> None:
+async def replay_actions(store: UboStore, path: Path) -> None:
     with path.open('r') as file:
         data = json.load(file)
 
     for item in data:
         store.dispatch(cast(Any, store.load_object(item)))
-        time.sleep(0.5)
+        await asyncio.sleep(0.5)
+    await asyncio.sleep(1.5)
+    store.dispatch(ReportReplayingDoneAction())


### PR DESCRIPTION
![ubo-screenshot-000](https://github.com/user-attachments/assets/441c03ba-e180-4b83-8541-d5caa1bca366)
![ubo-screenshot-001](https://github.com/user-attachments/assets/ded8e613-e817-44b4-a8c3-3c1f5ba8d3aa)
