### PR TITLE
Update polkit rules to allow sudo users to change wifi config

### DIFF
--- a/ubo_app/system/bootstrap.py
+++ b/ubo_app/system/bootstrap.py
@@ -175,7 +175,7 @@ def configure_fan() -> None:
 
 def setup_polkit() -> None:
     """Create the polkit rules file."""
-    with Path('/etc/polkit-1/rules.d/50-ubo.rules').open('w') as file:
+    with Path('/etc/polkit-1/rules.d/10-ubo.rules').open('w') as file:
         file.write(
             Path(__file__)
             .parent.joinpath('polkit.rules')

--- a/ubo_app/system/polkit.rules
+++ b/ubo_app/system/polkit.rules
@@ -1,10 +1,19 @@
 polkit.addRule(function(action, subject) {
-    if ((action.id == "org.freedesktop.login1.reboot" ||
-         action.id == "org.freedesktop.login1.reboot-multiple-sessions" ||
-         action.id == "org.freedesktop.login1.power-off" ||
-         action.id == "org.freedesktop.login1.power-off-multiple-sessions" ||
-         action.id.startsWith("org.freedesktop.NetworkManager.")) &&
-        subject.user == "{{USERNAME}}") {
-        return polkit.Result.YES;
+    if (subject.user == "{{USERNAME}}") {
+        // Special handling for settings.modify.system when user is in sudo group
+        if (action.id == "org.freedesktop.NetworkManager.settings.modify.system" &&
+            subject.isInGroup("sudo")) {
+            // Ensure we explicitly grant this permission regardless of local/active status
+            return polkit.Result.YES;
+        }
+        // All other NetworkManager and login1 actions
+        if (action.id == "org.freedesktop.login1.reboot" ||
+            action.id == "org.freedesktop.login1.reboot-multiple-sessions" ||
+            action.id == "org.freedesktop.login1.power-off" ||
+            action.id == "org.freedesktop.login1.power-off-multiple-sessions" ||
+            action.id.indexOf("org.freedesktop.NetworkManager.") == 0) {
+            return polkit.Result.YES;
+        }
     }
+    return polkit.Result.NOT_HANDLED;
 });

--- a/ubo_app/system/system_manager/scripts/set_account.sh
+++ b/ubo_app/system/system_manager/scripts/set_account.sh
@@ -39,6 +39,16 @@ fi
 echo "${USERNAME}:${PASSWORD}" | chpasswd
 printf "${USERNAME}:${PASSWORD}"
 
+# TODO: Create a seperate script to adding user to sudo group
+# and allowing passwordless sudo. Call this script with explict user action
+# exposed via the UI.
+
+# Add the user to the sudo group
+usermod -aG sudo $USERNAME
+
+# Allow the user to run sudo without a password
+echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME}
+
 # Allow password authentication
 sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
 systemctl restart ssh


### PR DESCRIPTION
This PR offers a fix for https://github.com/ubopod/ubo_app/issues/183.

For a complete solution, we need to implement https://github.com/ubopod/ubo_app/issues/184.

Context: The following system polkit rules is interfering with our custom design polkit rule:

```
ubo@ubo-ie:~ $ sudo ls -l /usr/share/polkit-1/rules.d/
total 16
-rw-r--r-- 1 root root 976 Jan 31  2023 49-polkit-pkla-compat.rules
-rw-r--r-- 1 root root 325 Jan 31  2023 50-default.rules
-rw-r--r-- 1 root root 282 Mar  9  2023 org.freedesktop.NetworkManager.rules
-rw-r--r-- 1 root root 527 Aug 19 21:25 systemd-networkd.rules


ubo@ubo-ie:~ $ sudo cat /usr/share/polkit-1/rules.d/org.freedesktop.NetworkManager.ru
les
polkit.addRule(function(action, subject) {
    if (action.id == "org.freedesktop.NetworkManager.settings.modify.system" &&
        subject.local && subject.active &&
        (subject.isInGroup ("sudo") || subject.isInGroup ("netdev"))) {
        return polkit.Result.YES;
    }
});
```

This rule specifically requires users in the sudo group to only modify system settings when they are both `local` and `active`, and it only covers the `settings.modify.system` action.

Based on the polkit documentation, local and active are attributes of the Subject type that indicate the session status:

- local (boolean):
Set to true only if the seat is local
A "local" seat means the user is physically present at the machine (like sitting at a desktop/laptop)
As opposed to a remote connection (like SSH or VNC)


- active (boolean):
Set to true only if the session is active
An "active" session means it's currently being used
For example, in a multi-user system with multiple logged-in users, only the currently focused/active user session would be marked as active
If you're logged in but switched to another user's session, your session would be inactive

