### PR TITLE
Make Add WiFi more reliable  

### DIFF
--- a/tests/flows/results/test_wireless/wireless_web_ui_flow/store-rpi-000.jsonc
+++ b/tests/flows/results/test_wireless/wireless_web_ui_flow/store-rpi-000.jsonc
@@ -1,0 +1,8 @@
+// store-rpi-000
+{
+  "_type": "WiFiState",
+  "connections": [],
+  "current_connection": null,
+  "has_visited_onboarding": null,
+  "state": "Disconnected"
+} 

--- a/tests/flows/results/test_wireless/wireless_web_ui_flow/store-rpi-001.jsonc
+++ b/tests/flows/results/test_wireless/wireless_web_ui_flow/store-rpi-001.jsonc
@@ -1,0 +1,26 @@
+// store-rpi-001
+{
+  "_type": "WiFiState",
+  "connections": [
+    {
+      "_type": "WiFiConnection",
+      "hidden": false,
+      "password": null,
+      "signal_strength": 100,
+      "ssid": "ubo-test-ssid",
+      "state": "Connected",
+      "type": null
+    }
+  ],
+  "current_connection": {
+    "_type": "WiFiConnection",
+    "hidden": false,
+    "password": null,
+    "signal_strength": 100,
+    "ssid": "ubo-test-ssid",
+    "state": "Connected",
+    "type": null
+  },
+  "has_visited_onboarding": null,
+  "state": "Connected"
+} 

--- a/tests/flows/results/test_wireless/wireless_web_ui_flow/store-rpi-002.jsonc
+++ b/tests/flows/results/test_wireless/wireless_web_ui_flow/store-rpi-002.jsonc
@@ -1,0 +1,18 @@
+// store-rpi-002
+{
+  "_type": "WiFiState",
+  "connections": [
+    {
+      "_type": "WiFiConnection",
+      "hidden": false,
+      "password": null,
+      "signal_strength": 100,
+      "ssid": "ubo-test-ssid",
+      "state": "Disconnected",
+      "type": null
+    }
+  ],
+  "current_connection": null,
+  "has_visited_onboarding": null,
+  "state": "Disconnected"
+} 

--- a/tests/flows/results/test_wireless/wireless_web_ui_flow/store-rpi-003.jsonc
+++ b/tests/flows/results/test_wireless/wireless_web_ui_flow/store-rpi-003.jsonc
@@ -1,0 +1,26 @@
+// store-rpi-003
+{
+  "_type": "WiFiState",
+  "connections": [
+    {
+      "_type": "WiFiConnection",
+      "hidden": false,
+      "password": null,
+      "signal_strength": 100,
+      "ssid": "ubo-test-ssid",
+      "state": "Connected",
+      "type": null
+    }
+  ],
+  "current_connection": {
+    "_type": "WiFiConnection",
+    "hidden": false,
+    "password": null,
+    "signal_strength": 100,
+    "ssid": "ubo-test-ssid",
+    "state": "Connected",
+    "type": null
+  },
+  "has_visited_onboarding": null,
+  "state": "Connected"
+} 

--- a/tests/flows/results/test_wireless/wireless_web_ui_flow/store-rpi-004.jsonc
+++ b/tests/flows/results/test_wireless/wireless_web_ui_flow/store-rpi-004.jsonc
@@ -1,0 +1,8 @@
+// store-rpi-004
+{
+  "_type": "WiFiState",
+  "connections": [],
+  "current_connection": null,
+  "has_visited_onboarding": null,
+  "state": "Disconnected"
+} 

--- a/tests/flows/results/test_wireless/wireless_web_ui_flow/store-rpi-005.jsonc
+++ b/tests/flows/results/test_wireless/wireless_web_ui_flow/store-rpi-005.jsonc
@@ -1,0 +1,8 @@
+// store-rpi-005
+{
+  "_type": "WiFiState",
+  "connections": [],
+  "current_connection": null,
+  "has_visited_onboarding": null,
+  "state": "Disconnected"
+} 

--- a/tests/flows/test_wireless.py
+++ b/tests/flows/test_wireless.py
@@ -240,10 +240,6 @@ async def test_wireless_web_ui_flow(
     def store_snapshot_selector(state: RootState) -> WiFiState:
         return state.wifi
 
-    # Set the snapshot directory for this test
-    store_snapshot.directory = 'test_wireless/wireless_web_ui_flow'
-    window_snapshot.directory = 'test_wireless/wireless_web_ui_flow'
-
     app_context.set_app()
     unload_waiter = await load_services(
         ['display', 'notifications', 'wifi'],

--- a/tests/flows/test_wireless.py
+++ b/tests/flows/test_wireless.py
@@ -200,3 +200,179 @@ async def test_wireless_flow(
     store_snapshot.take(selector=store_snapshot_selector)
 
     await unload_waiter()
+
+
+@pytest.mark.timeout(200)
+@pytest.mark.skipif(not IS_RPI, reason='Only runs on Raspberry Pi')
+async def test_wireless_web_ui_flow(
+    app_context: AppContext,
+    window_snapshot: WindowSnapshot,
+    store_snapshot: StoreSnapshot[RootState],
+    load_services: LoadServices,
+    stability: Stability,
+    wait_for: WaitFor,
+    wait_for_menu_item: WaitForMenuItem,
+    wait_for_empty_menu: WaitForEmptyMenu,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test adding WiFi connection via web UI."""
+    from sdbus_async.networkmanager import (  # pyright: ignore [reportMissingModuleSource]
+        AccessPoint,
+    )
+    from tenacity import wait_fixed
+
+    async def strength() -> int:
+        return 100
+
+    monkeypatch.setattr(
+        AccessPoint,
+        'strength',
+        property(lambda self: (self, strength())[1]),
+    )
+
+    from ubo_app.store.core.types import (
+        MenuChooseByIconAction,
+        MenuChooseByLabelAction,
+        MenuGoBackAction,
+    )
+    from ubo_app.store.main import store
+    from ubo_app.store.input.types import InputMethod
+
+    def store_snapshot_selector(state: RootState) -> WiFiState:
+        return state.wifi
+
+    app_context.set_app()
+    unload_waiter = await load_services(
+        ['display', 'notifications', 'wifi'],
+        run_async=True,
+    )
+
+    @wait_for(wait=wait_fixed(1), run_async=True)
+    def check_icon(expected_icon: str) -> None:
+        state = store._state  # noqa: SLF001
+        assert state is not None
+        icon = next(
+            (icon for icon in state.status_icons.icons if icon.id == 'wifi:state'),
+            None,
+        )
+        assert icon is not None, 'wifi icon not registered'
+        assert icon.symbol == expected_icon
+
+    await check_icon('󰖪')
+    await stability()
+    store_snapshot.take(selector=store_snapshot_selector)
+
+    # Select the main menu
+    store.dispatch(MenuChooseByIconAction(icon='󰍜'))
+    await stability()
+
+    # Select the settings menu
+    store.dispatch(MenuChooseByLabelAction(label='Settings'))
+    await stability()
+
+    # Go to network category
+    store.dispatch(MenuChooseByLabelAction(label='Network'))
+    await stability()
+
+    # Open the wireless menu
+    store.dispatch(MenuChooseByLabelAction(label='WiFi'))
+    await stability()
+    window_snapshot.take()
+
+    # Select "Add" to add a new connection
+    store.dispatch(MenuChooseByLabelAction(label='Add'))
+    await stability()
+
+    # Input method selection should be shown
+    window_snapshot.take()
+
+    # Select "Web Dashboard" input method
+    store.dispatch(MenuChooseByIconAction(icon='󰀶'))
+    await stability()
+
+    # Web UI form should be shown
+    window_snapshot.take()
+
+    # Simulate web UI input
+    from ubo_app.store.input.types import InputResult
+    store.dispatch(
+        InputResult(
+            method=InputMethod.WEB_DASHBOARD,
+            data={
+                'SSID': 'ubo-test-ssid',
+                'Password': 'test-password',
+                'Type': 'WPA2',
+                'Hidden': 'false',
+            },
+        ),
+    )
+
+    # Wait for hotspot to go down notification
+    await wait_for_menu_item(label='', icon='󱋆')
+    await stability()
+    window_snapshot.take()
+
+    # Wait for success notification
+    await check_icon('󰤨')
+    await wait_for_menu_item(label='', icon='󰆴')
+    store.dispatch(MenuChooseByIconAction(icon='󰆴'))
+    await stability()
+
+    # Select "Select" to open the wireless connection list and see the new connection
+    store.dispatch(MenuChooseByLabelAction(label='Select'))
+
+    @wait_for(wait=wait_fixed(1), run_async=True)
+    def check_connections() -> None:
+        state = store._state  # noqa: SLF001
+        assert state is not None
+        assert state.wifi.connections is not None
+
+    await check_connections()
+    await wait_for_menu_item(label='ubo-test-ssid', icon='󱚽')
+    store_snapshot.take(selector=store_snapshot_selector)
+    window_snapshot.take()
+
+    # Select the connection
+    store.dispatch(MenuChooseByLabelAction(label='ubo-test-ssid'))
+
+    # Wait for the "Disconnect" item to show up
+    await wait_for_menu_item(label='Disconnect')
+    await stability()
+    window_snapshot.take()
+    store.dispatch(MenuChooseByLabelAction(label='Disconnect'))
+
+    # Wait for the "Connect" item to show up
+    await wait_for_menu_item(label='Connect')
+    await check_icon('󰖪')
+    await stability()
+    store_snapshot.take(selector=store_snapshot_selector)
+    window_snapshot.take()
+    store.dispatch(MenuChooseByLabelAction(label='Connect'))
+
+    await wait_for_menu_item(label='Disconnect')
+    await check_icon('󰤨')
+    await stability()
+    store_snapshot.take(selector=store_snapshot_selector)
+    window_snapshot.take()
+    store.dispatch(MenuChooseByLabelAction(label='Delete'))
+
+    @wait_for(wait=wait_fixed(1), run_async=True)
+    def check_no_connections() -> None:
+        state = store._state  # noqa: SLF001
+        assert state
+        assert state.wifi.connections == []
+
+    await check_no_connections()
+    await check_icon('󰖪')
+    store_snapshot.take(selector=store_snapshot_selector)
+
+    # Dismiss the notification informing the user that the connection was deleted
+    await wait_for_menu_item(label='', icon='󰆴')
+    window_snapshot.take()
+    store.dispatch(MenuChooseByIconAction(icon='󰆴'))
+
+    await wait_for_empty_menu(placeholder='No Wi-Fi connections found')
+    window_snapshot.take()
+    store_snapshot.take(selector=store_snapshot_selector)
+
+    await unload_waiter()

--- a/tests/flows/test_wireless.py
+++ b/tests/flows/test_wireless.py
@@ -240,6 +240,10 @@ async def test_wireless_web_ui_flow(
     def store_snapshot_selector(state: RootState) -> WiFiState:
         return state.wifi
 
+    # Set the snapshot directory for this test
+    store_snapshot.directory = 'test_wireless/wireless_web_ui_flow'
+    window_snapshot.directory = 'test_wireless/wireless_web_ui_flow'
+
     app_context.set_app()
     unload_waiter = await load_services(
         ['display', 'notifications', 'wifi'],

--- a/tests/flows/test_wireless.py
+++ b/tests/flows/test_wireless.py
@@ -233,10 +233,9 @@ async def test_wireless_web_ui_flow(
     from ubo_app.store.core.types import (
         MenuChooseByIconAction,
         MenuChooseByLabelAction,
-        MenuGoBackAction,
     )
-    from ubo_app.store.main import store
     from ubo_app.store.input.types import InputMethod
+    from ubo_app.store.main import store
 
     def store_snapshot_selector(state: RootState) -> WiFiState:
         return state.wifi

--- a/tests/flows/test_wireless.py
+++ b/tests/flows/test_wireless.py
@@ -293,16 +293,21 @@ async def test_wireless_web_ui_flow(
     window_snapshot.take()
 
     # Simulate web UI input
-    from ubo_app.store.input.types import InputResult
+    from ubo_app.store.input.types import InputProvideAction, InputResult
     store.dispatch(
-        InputResult(
-            method=InputMethod.WEB_DASHBOARD,
-            data={
-                'SSID': 'ubo-test-ssid',
-                'Password': 'test-password',
-                'Type': 'WPA2',
-                'Hidden': 'false',
-            },
+        InputProvideAction(
+            id='wifi-connection',
+            value='',
+            result=InputResult(
+                method=InputMethod.WEB_DASHBOARD,
+                data={
+                    'SSID': 'ubo-test-ssid',
+                    'Password': 'test-password',
+                    'Type': 'WPA2',
+                    'Hidden': 'false',
+                },
+                files={},
+            ),
         ),
     )
 


### PR DESCRIPTION
This PR attempts to address https://github.com/ubopod/ubo_app/issues/247

1. It adds better exception handling during wifi service initialization 
2. retries a few times if `add_wifi_connection` fails with `sdbus_async.networkmanager.exceptions.NetworkManagerUnknownConnectionError` exception.  