### PR TITLE
refactor(core,audio,display,keypad,sensors): read and check content of eeprom to determine if a device/service should be initialized or not - closes #223, #closes #249

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - refactor(voice): upgrade `access_key` input to use the new `fields` value of the `InputDescription`
 - refactor(web-ui): use the same mui interface in static server too (instead of jinja-rendered interface) and add action buttons for all status reported by server - closes #224
 - fix(rpi-connect): use `with_state` of the latest python-redux version instead of `view` to avoid memoization of actions - closes #248
+- refactor(core,audio,display,keypad,sensors): read and check content of eeprom to determine if a device/service should be initialized or not - closes #223, #closes #249
 
 ## Version 1.2.2
 

--- a/ubo_app/services/000-keypad/setup.py
+++ b/ubo_app/services/000-keypad/setup.py
@@ -17,6 +17,7 @@ from ubo_app.store.services.keypad import (
     KeypadKeyReleaseAction,
 )
 from ubo_app.utils import IS_RPI
+from ubo_app.utils.eeprom import get_eeprom_data
 
 if TYPE_CHECKING:
     import busio
@@ -279,4 +280,11 @@ class Keypad:
 def init_service() -> None:
     if not IS_RPI:
         return
-    Keypad()
+    eeprom_data = get_eeprom_data()
+    if (
+        eeprom_data is not None
+        and 'keypad' in eeprom_data
+        and eeprom_data['keypad']
+        and eeprom_data['keypad']['model'] == 'aw9523'
+    ):
+        Keypad()

--- a/ubo_app/services/040-rgb-ring/setup.py
+++ b/ubo_app/services/040-rgb-ring/setup.py
@@ -1,9 +1,20 @@
 # ruff: noqa: D100, D101, D102, D103, D104, D107, N999
 from ubo_app.store.main import store
 from ubo_app.store.services.rgb_ring import RgbRingCommandEvent, RgbRingPulseAction
+from ubo_app.utils.eeprom import get_eeprom_data
 
 
 def init_service() -> None:
+    eeprom_data = get_eeprom_data()
+
+    if (
+        eeprom_data is None
+        or 'led' not in eeprom_data
+        or eeprom_data['led'] is None
+        or eeprom_data['led']['model'] != 'neopixel'
+    ):
+        return
+
     from rgb_ring_client import RgbRingClient
 
     rgb_ring_client = RgbRingClient()

--- a/ubo_app/services/040-sensors/setup.py
+++ b/ubo_app/services/040-sensors/setup.py
@@ -15,18 +15,19 @@ from tenacity import retry, retry_if_exception, stop_after_attempt, wait_fixed
 from ubo_app.logger import logger
 from ubo_app.store.main import store
 from ubo_app.store.services.sensors import Sensor, SensorsReportReadingAction
+from ubo_app.utils.eeprom import get_eeprom_data
 
 if TYPE_CHECKING:
     from adafruit_rgb_display.rgb import busio
 
-temperature_sensor: adafruit_pct2075.PCT2075
-light_sensor: adafruit_veml7700.VEML7700
+temperature_sensor: adafruit_pct2075.PCT2075 | None = None
+light_sensor: adafruit_veml7700.VEML7700 | None = None
 
 
 def read_sensors(_: float | None = None) -> None:
     """Read the sensor."""
-    temperature = temperature_sensor.temperature
-    light = light_sensor.lux
+    temperature = 0.0 if temperature_sensor is None else temperature_sensor.temperature
+    light = 0.0 if light_sensor is None else light_sensor.lux
     store.dispatch(
         SensorsReportReadingAction(
             sensor=Sensor.TEMPERATURE,
@@ -60,16 +61,38 @@ def init_service() -> None:
     """Initialize the service."""
     from kivy.clock import Clock
 
+    eeprom_data = get_eeprom_data()
+
     global temperature_sensor, light_sensor  # noqa: PLW0603
 
     i2c = board.I2C()
     try:
-        temperature_sensor = _initialize_device(adafruit_pct2075.PCT2075, 0x48, i2c)
+        if (
+            eeprom_data is not None
+            and 'temperature' in eeprom_data
+            and eeprom_data['temperature'] is not None
+            and eeprom_data['temperature']['model'].upper() == 'PCT2075'
+        ):
+            temperature_sensor = _initialize_device(
+                adafruit_pct2075.PCT2075,
+                int(eeprom_data['temperature']['bus_address'], 16),
+                i2c,
+            )
     except Exception:
         logger.exception('Error initializing temperature sensor')
 
     try:
-        light_sensor = _initialize_device(adafruit_veml7700.VEML7700, 0x10, i2c)
+        if (
+            eeprom_data is not None
+            and 'ambient' in eeprom_data
+            and eeprom_data['ambient'] is not None
+            and eeprom_data['ambient']['model'].upper() == 'VEML7700'
+        ):
+            light_sensor = _initialize_device(
+                adafruit_veml7700.VEML7700,
+                int(eeprom_data['ambient']['bus_address'], 16),
+                i2c,
+            )
     except Exception:
         logger.exception('Error initializing light sensor')
 

--- a/ubo_app/store/update_manager/types.py
+++ b/ubo_app/store/update_manager/types.py
@@ -18,7 +18,7 @@ class UpdateManagerSetVersionsAction(UpdateManagerAction):
     current_version: str
     base_image_variant: str
     latest_version: str
-    serial_number: str
+    serial_number: str | None
 
 
 class UpdateManagerSetStatusAction(UpdateManagerAction):

--- a/ubo_app/utils/eeprom.py
+++ b/ubo_app/utils/eeprom.py
@@ -1,21 +1,177 @@
 """Utility functions for interacting with the EEPROM."""
 
 import json
+from functools import cache
 from pathlib import Path
+from typing import TypedDict
 
 from ubo_app.logger import logger
 from ubo_app.utils import IS_RPI
 
 
-def read_serial_number() -> str:
+class SoundTestReport(TypedDict):
+    """Sound test report."""
+
+    left: bool
+    right: bool
+
+
+class TemperatureTestReport(TypedDict):
+    """Temperature test report."""
+
+    degrees: float
+
+
+class AmbientTestReport(TypedDict):
+    """Ambient test report."""
+
+    works: bool
+    baseline: float
+    reading: float
+    delta: float
+
+
+class KeypadTestReport(TypedDict):
+    """Keypad test report."""
+
+    L1: bool
+    L2: bool
+    L3: bool
+    UP: bool
+    DOWN: bool
+    BACK: bool
+    HOME: bool
+    MIC: bool
+
+
+class LCDTestReport(TypedDict):
+    """LCD test report."""
+
+    qrcode: bool
+    green: bool
+    red: bool
+    blue: bool
+
+
+class LEDTestReport(TypedDict):
+    """LED test report."""
+
+    green: bool
+    red: bool
+    blue: bool
+
+
+class Device(TypedDict):
+    """Device information."""
+
+    model: str
+    bus_address: str
+    test_result: bool
+
+
+class EepromDevice(Device):
+    """EEPROM device information."""
+
+
+class SpeakersDevice(Device):
+    """Speakers device information."""
+
+    test_report: SoundTestReport
+
+
+class MicrophonesDevice(Device):
+    """Microphones device information."""
+
+    test_report: SoundTestReport
+
+
+class TemperatureDevice(Device):
+    """Temperature device information."""
+
+    test_report: TemperatureTestReport
+
+
+class AmbientDevice(Device):
+    """Ambient device information."""
+
+    test_report: AmbientTestReport
+
+
+class KeypadDevice(Device):
+    """Keypad device information."""
+
+    test_report: KeypadTestReport
+
+
+class LCDDevice(Device):
+    """LCD device information."""
+
+    test_report: LCDTestReport
+
+
+class LEDDevice(Device):
+    """LED device information."""
+
+    test_report: LEDTestReport
+
+
+class InfraredDevice(Device):
+    """Infrared device information."""
+
+    test_result: bool
+
+
+class I2CBus(TypedDict):
+    """I2C bus information."""
+
+    num_devices: int
+    scanned_addressed: list[str]
+    status: str
+
+
+class EepromData(TypedDict):
+    """EEPROM data."""
+
+    serial_number: str
+    eeprom: EepromDevice | None
+    speakers: SpeakersDevice | None
+    microphones: MicrophonesDevice | None
+    temperature: TemperatureDevice | None
+    ambient: AmbientDevice | None
+    keypad: KeypadDevice | None
+    i2c_bus: I2CBus | None
+    lcd: LCDDevice | None
+    led: LEDDevice | None
+    infrared: InfraredDevice | None
+    version: str
+    timedate: str | None
+    test_result: bool | None
+
+
+@cache
+def get_eeprom_data() -> EepromData | None:
+    """Read the EEPROM data."""
+    if not IS_RPI:
+        return None
+    try:
+        eeprom_json_data = Path(
+            '/proc/device-tree/hat/custom_0',
+        ).read_text(encoding='utf-8')
+        eeprom_data = json.loads(eeprom_json_data)
+    except Exception:
+        logger.exception('Failed to read EEPROM data')
+        return None
+    else:
+        if 'serial_number' not in eeprom_data or 'version' not in eeprom_data:
+            return None
+        return eeprom_data
+
+
+def read_serial_number() -> str | None:
     """Read the serial number from the EEPROM."""
     if IS_RPI:
-        try:
-            eeprom_json_data = Path(
-                '/proc/device-tree/hat/custom_0',
-            ).read_text(encoding='utf-8')
-            eeprom_data = json.loads(eeprom_json_data)
-            return eeprom_data['serial_number']
-        except Exception:
-            logger.exception('Failed to read serial number')
+        data = get_eeprom_data()
+        if data is not None:
+            return data['serial_number']
+        return None
     return '<not-available>'


### PR DESCRIPTION
This pull request adds `get_eeprom_data()` which reads the content of the eeprom memory and returns it as a `TypedDict`.

Initialization of audio, rgb-ring, display, sensors and keypad, are now conditional based on whether the expected model of the required module is reported to be installed on the device.