### PR TITLE
fix(display): decrease baudrate from 70,000,000 to 60,000,000 to avoid residual noise on the display - closes #236

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - fix(core): add `task_runner` parameter to `async_.create_task` and use it with `async_.get_task_runner` in store event handlers instead of directly calling the task runner to make sure a reference to tasks are stored in the memory until they are finished, handle by `async_.create_task` - closes #247, closes #266
 - chore: update pyright and fix/silent newly reported type errors
 - fix(core): improve `has_gateway` utility function to ignore default routes with local scope - closes #251
+- fix(display): decrease baudrate from 70,000,000 to 60,000,000 to avoid residual noise on the display - closes #236
 
 ## Version 1.2.2
 

--- a/ubo_app/constants.py
+++ b/ubo_app/constants.py
@@ -68,6 +68,7 @@ CONFIG_PATH = platformdirs.user_config_path(appname='ubo', ensure_exists=True)
 SECRETS_PATH = CONFIG_PATH / '.secrets.env'
 PERSISTENT_STORE_PATH = CONFIG_PATH / 'state.json'
 
+DISPLAY_BAUDRATE = int(os.environ.get('UBO_DISPLAY_BAUDRATE', '60_000_000'))
 WIDTH = 240
 HEIGHT = 240
 BYTES_PER_PIXEL = 2

--- a/ubo_app/display.py
+++ b/ubo_app/display.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from headless_kivy.config import Region
 
 
-from ubo_app.constants import HEIGHT, WIDTH
+from ubo_app.constants import DISPLAY_BAUDRATE, HEIGHT, WIDTH
 
 
 class Display:
@@ -61,7 +61,7 @@ class Display:
                     cs=self.cs_pin,
                     dc=self.dc_pin,
                     rst=self.reset_pin,
-                    baudrate=70_000_000,
+                    baudrate=DISPLAY_BAUDRATE,
                 )
         else:
             self.display = cast('ST7789', Fake())

--- a/ubo_app/main.py
+++ b/ubo_app/main.py
@@ -51,12 +51,18 @@ def main() -> None:
 
     import headless_kivy.config
 
-    from ubo_app.constants import DISABLE_GRPC, HEIGHT, WIDTH
+    from ubo_app.constants import (
+        BYTES_PER_PIXEL,
+        DISABLE_GRPC,
+        DISPLAY_BAUDRATE,
+        HEIGHT,
+        WIDTH,
+    )
     from ubo_app.display import render_on_display
 
     headless_kivy.config.setup_headless_kivy(
         headless_kivy.config.SetupHeadlessConfig(
-            bandwidth_limit=70 * 1000 * 1000 // 8 // 2 if IS_RPI else 0,
+            bandwidth_limit=DISPLAY_BAUDRATE // BYTES_PER_PIXEL // 8 if IS_RPI else 0,
             bandwidth_limit_window=0.03,
             bandwidth_limit_overhead=10000,
             region_size=60,


### PR DESCRIPTION
I think the residual pixel noise was happening because we assumed higher bandwidth than what the lcd has in reality, I decreased it and couldn't reproduce it on my Pi 4 anymore.