### PR TITLE
fix(sensors): explicitly set the `light_integration_time` for the light sensor - closes #269

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - refactor: avoid using `Clock.schedule_interval` and replace it with `asyncio.sleep` in services needing to periodically run a function
 - test: add `test_menu`, as the first in a category of tests purposed to reproduce rare and hard-to-reproduce bugs: these tests run a few times normally, but when `UBO_TEST_INVESTIGATION_MODE` environment variable is set, they repeat the expected reproduction steps thousands of times until the bug is reproduced, and then run a pdb session for investigation
 - refactor(services): better error representation containing more content in a single page
+- fix(sensors): explicitly set the `light_integration_time` for the light sensor - closes #269
 
 ## Version 1.2.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "adafruit-circuitpython-neopixel>=6.3.11",
   "adafruit-circuitpython-pct2075>=1.1.21",
   "adafruit-circuitpython-rgb-display>=3.11.0",
-  "adafruit-circuitpython-veml7700>=1.1.22",
+  "adafruit-circuitpython-veml7700>=2.1.2",
   # RPi dependencies
   "piper-tts>=1.2.0 ; sys_platform=='linux'",
   "rpi-lgpio>=0.6 ; platform_machine=='aarch64'",

--- a/tests/fixtures/mock_environment.py
+++ b/tests/fixtures/mock_environment.py
@@ -129,6 +129,7 @@ def _monkeypatch_rpi_modules() -> None:
     class FakeSensor(Fake):
         lux = 0.0
         temperature = 0.0
+        ALS_50MS = 0
 
     class FakeSensorModule(Fake):
         PCT2075 = FakeSensor

--- a/ubo_app/services/040-sensors/setup.py
+++ b/ubo_app/services/040-sensors/setup.py
@@ -56,7 +56,7 @@ T = TypeVar('T', bound=adafruit_pct2075.PCT2075 | adafruit_veml7700.VEML7700)
     ),
 )
 def _initialize_device(cls: type[T], address: int, i2c: busio.I2C) -> T:
-    """Initialize the I2C."""
+    """Initialize the I2C device."""
     return cls(i2c, address)
 
 
@@ -100,6 +100,7 @@ def init_service() -> Subscriptions:
                 int(eeprom_data['ambient']['bus_address'], 16),
                 i2c,
             )
+            light_sensor.light_integration_time = adafruit_veml7700.VEML7700.ALS_50MS
     except Exception:
         logger.exception('Error initializing light sensor')
 

--- a/uv.lock
+++ b/uv.lock
@@ -1892,7 +1892,7 @@ requires-dist = [
     { name = "adafruit-circuitpython-neopixel", specifier = ">=6.3.11" },
     { name = "adafruit-circuitpython-pct2075", specifier = ">=1.1.21" },
     { name = "adafruit-circuitpython-rgb-display", specifier = ">=3.11.0" },
-    { name = "adafruit-circuitpython-veml7700", specifier = ">=1.1.22" },
+    { name = "adafruit-circuitpython-veml7700", specifier = ">=2.1.2" },
     { name = "aiohttp", specifier = ">=3.9.1" },
     { name = "betterproto", extras = ["compiler"], specifier = ">=2.0.0b7" },
     { name = "dill", specifier = ">=0.3.8" },


### PR DESCRIPTION
After [this pull request](https://github.com/adafruit/Adafruit_CircuitPython_VEML7700/pull/29/files), light sensor stopped working, raising an error since the `light_integration_time` was set on the device to 11, but the value 11 is not a valid value for this parameter after that pull request is merged.

Now we explicitly set `light_integration_time` after initializing `VEML7700` to `adafruit_veml7700.VEML7700.ALS_50MS`.