### PR TITLE
Audio fix: replace waveshare repo with ubopod fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - fix(ip): make sure the connection status is set to not-connected when ping is not generating any output
 - refactor(services): avoid silencing caught exceptions in services by either reraising them so that they are caught and reported by the global exception handler or directly reporting them
 - fix(audio): make audio run the `unbind` and `bind` sequence if the audio card is not listed by `alsaaudio.cards`
+- fix(audio): replace wareshare repo with ubopod fork
 
 ## Version 1.2.2
 

--- a/ubo_app/system/install_wm8960.sh
+++ b/ubo_app/system/install_wm8960.sh
@@ -18,10 +18,11 @@ fi
 
 #download the archive
 rm -rf WM8960-Audio-HAT
-git clone https://github.com/waveshare/WM8960-Audio-HAT
+git clone https://github.com/ubopod/WM8960-Audio-HAT
 cd WM8960-Audio-HAT
 
 apt-get -y update
+apt-get -y upgrade
 apt-get -y install raspberrypi-kernel-headers --no-install-recommends --no-install-suggests
 apt-get -y install dkms git i2c-tools libasound2-plugins --no-install-recommends --no-install-suggests
 apt-get -y clean
@@ -52,8 +53,8 @@ function install_module {
   dkms add -m $mod -v $ver
   for kernel in $kernels
   do
-    # It works for kernels greater than or equal 6.5
-    if [ $(echo "$kernel 6.5" | awk '{if ($1 >= $2) print 1; else print 0}') -eq 0 ]; then
+    # It works for kernels greater than or equal 6.12
+    if [ "$(printf '%s\n' "$kernel" "6.12" | sort -V | head -n1)" = "$kernel" ]; then
       continue
     fi
     dkms build "$kernel" -k "$kernel" --kernelsourcedir "/lib/modules/$kernel/build" -m $mod -v $ver &&


### PR DESCRIPTION
Since late March 2025, `apt upgrade` bumps kernel version to `6.12.20` which breaks audio drivers. This PR replaces `waveshare` repo with fork on `ubopod` repo that fixes this issue. 

I have opened a PR https://github.com/waveshareteam/WM8960-Audio-HAT/pull/70 on the upstream repo to get these changes merged but in the meantime, we can point to our own repo. 