### PR TITLE
release/v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - fix(audio): make audio run the `unbind` and `bind` sequence if the audio card is not listed by `alsaaudio.cards`
 - fix(audio): replace wareshare repo with ubopod fork
 - refactor(wifi): show wifi onboarding only on ubo-pod, and initiate the wifi input over hotspot on non-ubo-pods
+- fix(audio): make sure `set_playback_mute`, `set_playback_volume` and `set_capture_volume` are applied on the audio card, even if audio manager is not initialized when these methods are called
 
 ## Version 1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Upcoming
+## Version 1.3.0
 
 - fix: remove dependencies of `publish` job of `publish_to_pypi` workflow
 - fix: vscode binary now needs to be instructed about the location of the binary with `version use` sub-command - closes #217

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - refactor(services): avoid silencing caught exceptions in services by either reraising them so that they are caught and reported by the global exception handler or directly reporting them
 - fix(audio): make audio run the `unbind` and `bind` sequence if the audio card is not listed by `alsaaudio.cards`
 - fix(audio): replace wareshare repo with ubopod fork
+- refactor(wifi): show wifi onboarding only on ubo-pod, and initiate the wifi input over hotspot on non-ubo-pods
 
 ## Version 1.2.2
 

--- a/ubo_app/services/000-audio/audio_manager.py
+++ b/ubo_app/services/000-audio/audio_manager.py
@@ -44,6 +44,10 @@ class AudioManager:
         self.has_speakers = False
         self.has_microphones = False
 
+        self.playback_mute = True
+        self.playback_volume = 0.1
+        self.capture_volume = 0.1
+
         async def initialize_audio() -> None:
             for _ in range(TRIALS):
                 try:
@@ -55,6 +59,10 @@ class AudioManager:
                     logger.exception('No audio card found')
                     await send_command('audio', 'failure_report', has_output=True)
                 else:
+                    # In case they were set before the card was initialized
+                    self.set_playback_mute(mute=self.playback_mute)
+                    self.set_playback_volume(self.playback_volume)
+                    self.set_capture_volume(self.capture_volume)
                     break
                 await asyncio.sleep(1)
 
@@ -167,6 +175,7 @@ class AudioManager:
             Mute to set
 
         """
+        self.playback_mute = mute
         try:
             # Assume pulseaudio is installed
             mixer = alsaaudio.Mixer(control='Master')
@@ -196,6 +205,7 @@ class AudioManager:
             Volume to set, a float between 0 and 1
 
         """
+        self.playback_volume = volume
         if volume < 0 or volume > 1:
             msg = 'Volume must be between 0 and 1'
             raise ValueError(msg)
@@ -230,6 +240,7 @@ class AudioManager:
             Volume to set, a float between 0 and 1
 
         """
+        self.capture_volume = volume
         if volume < 0 or volume > 1:
             msg = 'Volume must be between 0 and 1'
             raise ValueError(msg)


### PR DESCRIPTION
Change log:

- fix: remove dependencies of `publish` job of `publish_to_pypi` workflow
- fix: vscode binary now needs to be instructed about the location of the binary with `version use` sub-command - closes #217
- fix: image size being too big for the lite version of the raspberry os
- fix: restart avahi-daemon after the hostname is set in `ubo-system`
- feat: add support for `set`s and `dict`s for rpc api
- feat: `{{hostname}}`, as a template variable, will be replaced with the hostname of the device whenever used in `title` and `content` properties of a `Notification` instance or in the `text`, `picovoice_text` or `piper_text` properties of a `ReadableInformation` instance.
- refactor: minor improvements like add `volume` to `AudioPlayAudioEvent`, metric's `density` of kivy to `DisplayRenderEvent` and `DisplayCompressedRenderEvent`, some housekeeping in syntax, logs and ci/cd scripts
- refactor: to make it easier for other modules to interact with docker containers and compositions, there is now a store action for each interaction and now they run as side effects of those store actions dispatched to the store, instead of directly calling functions
- feat(web-ui): implement react web application for the web-ui service - closes #224
- refactor(web-ui): use mui dialogs for input demands - closes #224
- chore(web-ui): add linting and formatting to the web application code - closes #224
- refactor(web-ui): use webaudio for audio playback in the web application and add an unmute button - closes #224
- feat(web-ui): add side buttons layout, and handle swipe gestures for the web application - closes #224
- feat(web-ui): add dark-mode support for layout buttons and add color scheme switch buttons - closes #224
- fix(web-ui): provide input field for when there is no `fields` nor `pattern` in the `InputDescription`
- refactor(voice): upgrade `access_key` input to use the new `fields` value of the `InputDescription`
- refactor(web-ui): use the same mui interface in static server too (instead of jinja-rendered interface) and add action buttons for all status reported by server - closes #224
- fix(rpi-connect): use `with_state` of the latest python-redux version instead of `view` to avoid memoization of actions - closes #248
- refactor(core,audio,display,keypad,sensors): read and check content of eeprom to determine if a device/service should be initialized or not - closes #223, #closes #249
- fix(core): improve syntax of `str_to_bool`, removing all unnecessary `== 1` postfixes
- feat(core): implement services menu in settings for controlling services - closes #4, closes #226
- feat(core): store services configuration into and read them from the persistent store
- refactor: use the new subscriptions return value of the `setup` function for different services to report subscriptions so that the service manager can clean up the subscriptions when the service is stopped
- fix(core): remove the reference of the async task handle after it is done to avoid memory leaks
- feat(core): clean up status icons of a service when it stops
- refactor(tests): make different parts of code explicitly return their cleanup functions and make test_services wait until all services are completely loaded without any errors plus small improvements to logs
- chore(lint): update ruff to the latest version and update codebase to be compatible with it
- build(installation): remove the line in install.sh uninstalling `RPI.GPIO` as it is no longer needed with the latest release of adafruit-blinka
- build(installation): remove the raspberry pi's ssh daemon banner warning about setting a valid user
- refactor(core): make `subscribe_event` created in services, run the handler in the event loop of the service instead of the event loop of the main thread - closes #226
- refactor: add `ubo_app.colors` and move hardcoded color codes to it
- feat: add menu switch for service threads to enable/disable auto-run and auto-rerun of services - closes #227
- build(install): avoid swallowing stdout of the `pip install` command in the `install.sh`, lock onnxruntime to 1.20.1, related: <https://github.com/microsoft/onnxruntime/issues/23957>
- test: improve cleanup and add explicit wait for loaded services to unload at the end of `test_services` test
- feat(core): add a barrier for services after they register their reducer, they will pass it only when the rest of them have registered their reducer - closes #163
- refactor(core): replace `kivy.clock.Clock.create_trigger` as the scheduler of the store with a new in house implementation of a scheduler using `asyncio` running in a separate thread and multiple improvements in resource cleanup, test utilities to ensure tests are reproducible and don't fail randomly
- docs: add a section for adding new services, mentioning general patterns, to avoid common mistakes
- refactor(core): better handle circular references in formatting log messages
- fix(core): wrap `callback` call of the scheduler in `try` to avoid the scheduler stopping when an exception is raised in its thread
- refactor(docker): make docker container menus load even if `ip` service is not available
- test: mock `has_gateway` and better mock `send_command` to make it return `done` instead of `Connected` when the command is not `connection`
- refactor(core): use latest version of `python-redux` and `ubo-gui` and remove all `@mainthread` decorators for actions on the menu as `ubo-gui` now takes care of running them in the main thread itself
- fix(core): improve resource cleanup of service threads so that they can be restarted after being stopped
- refactor(core): defer attaching the main reducer to the root reducer using `CombineReducerRegisterAction` to avoid circular imports or sacrificing the purity of reducers.
- fix(core): add cleanup for gpio pins including display pins and run `gpiozero.devices._shutdown` as part of the cleanup process
- test: wait for scheduler to completely stop before stopping the kivy app to make sure no `kivy.clock.Clock` event gets scheduled after the app is stopped
- fix(core): add display cleanup for raspberry pi 4 as adafruit uses `RPi.GPIO` in pi 4 instead of `lgpio` which it uses for pi 5 and we already have a cleanup for it
- test: add `UBO_TEST_INVESTIGATION_MODE` to enable advanced and costly tools like recording stack-trace of `cell`s, generating dependency graph using `objgraph` and running pdb session when memory leak is found to better investigate memory leaks
- test: move all dbus custom interfaces in `ubo_app.utils.dbus_interfaces` and preserve it in test cleanup, this is due to sdbus having a hidden mapping of dbus interfaces to their implementations in the C code and it doesn't clean up the mapping when the interface is removed
- refactor: avoid using `Clock.schedule_interval` and replace it with `asyncio.sleep` in services needing to periodically run a function
- test: add `test_menu`, as the first in a category of tests purposed to reproduce rare and hard-to-reproduce bugs: these tests run a few times normally, but when `UBO_TEST_INVESTIGATION_MODE` environment variable is set, they repeat the expected reproduction steps thousands of times until the bug is reproduced, and then run a pdb session for investigation
- refactor(services): better error representation containing more content in a single page
- fix(sensors): explicitly set the `light_integration_time` for the light sensor - closes #269
- fix(core): add `task_runner` parameter to `async_.create_task` and use it with `async_.get_task_runner` in store event handlers instead of directly calling the task runner to make sure a reference to tasks are stored in the memory until they are finished, handle by `async_.create_task` - closes #247, closes #266
- chore: update pyright and fix/silent newly reported type errors
- fix(core): improve `has_gateway` utility function to ignore default routes with local scope - closes #251
- fix(display): decrease baudrate from 70,000,000 to 60,000,000 to avoid residual noise on the display - closes #236
- fix(web-ui): don't interpret keys pressed outside the `#web-app-root`, or keys pressed on `HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement` and `HTMLButtonElement` as interactions with the pod
- fix(system): make system process completely exit when it's done so that systemd can restart it, the exit used to get blocked by the `check_connection` thread, also make it not exit simply because a client sends an empty datagram, the client may have crashed but system process doesn't need to exit - closes #272
- refactor(ip): remove python-ping package and the connection monitoring code in the system-manager, use system ping command instead, this is because none of the python packages providing ping functionality are actively maintained and ping command has the benefit of not needing to run as root, lowering the communication traffic between the system process and the main process - closes #267
- refactor(core): move setting gpio 17 to `config.txt` so that it happens on boot and remove it from `hardware_initialization`
- refactor(core): make the scheduler compensate for the time it took to run the last scheduled event, by waiting less time in the next scheduled event, also sync its frequency with the frequency of the display updates
- feat(core): handle system signal `USR1` as the signal to initiate `ipdb` only if `DEBUG_MODE_PDB_SIGNAL` is set
- refactor(system): improve the user experience of the reset button, add a pattern for restarting the app without killing it
- refactor(core): add unified API to access “current service” via thread-local, parent thread, or call stack
- refactor(core): better representation of errors in logs and service menus
- fix(ip): make sure the connection status is set to not-connected when ping is not generating any output
- refactor(services): avoid silencing caught exceptions in services by either reraising them so that they are caught and reported by the global exception handler or directly reporting them
- fix(audio): make audio run the `unbind` and `bind` sequence if the audio card is not listed by `alsaaudio.cards`
- fix(audio): replace wareshare repo with ubopod fork
- refactor(wifi): show wifi onboarding only on ubo-pod, and initiate the wifi input over hotspot on non-ubo-pods
- fix(audio): make sure `set_playback_mute`, `set_playback_volume` and `set_capture_volume` are applied on the audio card, even if audio manager is not initialized when these methods are called