### PR TITLE
Isolate autoruns in service threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - refactor(core): use the new `StoreOptions.autorun_class` of `python-redux` to make sure they run in the service thread they were defined in - closes #286
 - fix(audio): use `tenacity` for retry logic and add a one second delay between retries when playback fails
 - fix(installation): gracefully handle missing file in sed command with || true - closes #281
+- refactor(audio): make setter functions in audio manager try finding card index again and rebind in case of failure
 
 ## Version 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fix(web-ui): add the missing read command for the file input values in html forms
 - docs: update README.md to add instructions for generating protobufs, web static assets, and running typecheck
 - refactor(core): use the new `StoreOptions.autorun_class` of `python-redux` to make sure they run in the service thread they were defined in - closes #286
+- fix(audio): use `tenacity` for retry logic and add a one second delay between retries when playback fails
 
 ## Version 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - refactor(infrared): replace `adafruit-ir-remote` with `ir-keytable` to lower CPU usage and improve code compatibility
 - fix(web-ui): add the missing read command for the file input values in html forms
 - docs: update README.md to add instructions for generating protobufs, web static assets, and running typecheck
+- refactor(core): use the new `StoreOptions.autorun_class` of `python-redux` to make sure they run in the service thread they were defined in - closes #286
 
 ## Version 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - docs: update README.md to add instructions for generating protobufs, web static assets, and running typecheck
 - refactor(core): use the new `StoreOptions.autorun_class` of `python-redux` to make sure they run in the service thread they were defined in - closes #286
 - fix(audio): use `tenacity` for retry logic and add a one second delay between retries when playback fails
+- fix(installation): gracefully handle missing file in sed command with || true - closes #281
 
 ## Version 1.3.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "python-debouncer>=0.1.5",
   "python-dotenv>=1.0.1",
   "python-fake>=0.2.0",
-  "python-redux>=0.22.2",
+  "python-redux>=0.23.0",
   "python-strtobool>=1.0.0",
   "pyzbar>=0.1.9",
   "quart>=0.19.6",
@@ -85,7 +85,7 @@ dev-dependencies = [
   "pdbpp>=0.10.3",
   "poethepoet>=0.24.4",
   "pyfakefs>=5.7.4",
-  "pyright>=1.1.399",
+  "pyright>=1.1.400",
   "pytest>=8.0.0",
   "pytest-asyncio>=0.23.5.post1",
   "pytest-cov>=4.1.0",
@@ -93,7 +93,7 @@ dev-dependencies = [
   "pytest-repeat>=0.9.3",
   "pytest-timeout>=2.3.1",
   "pytest-xdist>=3.5.0",
-  "ruff>=0.10.0",
+  "ruff>=0.11.8",
   "toml>=0.10.2",
 ]
 

--- a/tests/fixtures/app.py
+++ b/tests/fixtures/app.py
@@ -73,10 +73,6 @@ class AppContext:
         PERSISTENT_STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
         PERSISTENT_STORE_PATH.write_text(json.dumps(self.persistent_store_data))
 
-        from ubo_app.service import start_event_loop_thread
-
-        start_event_loop_thread(asyncio.new_event_loop())
-
         from ubo_app.menu_app.menu import MenuApp
 
         if app is None:

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -35,7 +35,7 @@ async def test_all_services_register(
     app_context.set_app()
     unload_waiter = await load_services(CORE_SERVICE_IDS, timeout=40, run_async=True)
 
-    await stability(attempts=2, wait=2)
+    await stability(initial_wait=2, attempts=2, wait=2)
 
     assert len(store._listeners) < MAX_EXPECTED_LISTENERS  # noqa: SLF001
     assert len(store._event_handlers) < MAX_EXPECTED_EVENT_HANDLERS  # noqa: SLF001

--- a/ubo_app/display.py
+++ b/ubo_app/display.py
@@ -9,7 +9,6 @@ import numpy as np
 from adafruit_rgb_display.st7789 import ST7789
 from fake import Fake
 
-from ubo_app.store.main import store
 from ubo_app.store.services.display import (
     DisplayCompressedRenderEvent,
     DisplayRenderEvent,
@@ -119,6 +118,7 @@ class Display:
         bypass_pause: bool = False,
     ) -> None:
         """Block the display."""
+        from ubo_app.store.main import store
 
         @store.with_state(
             lambda state: state.display.is_paused
@@ -184,6 +184,8 @@ def render_on_display(*, regions: list[Region]) -> None:
         )
 
     if not IS_TEST_ENV:
+        from ubo_app.store.main import store
+
         store._dispatch(  # noqa: SLF001
             [event for region in regions for event in generate_render_actions(region)],
         )

--- a/ubo_app/main.py
+++ b/ubo_app/main.py
@@ -1,7 +1,6 @@
 # ruff: noqa: D100, D101, D102, D103, D104, D107
 from __future__ import annotations
 
-import asyncio
 import os
 from pathlib import Path
 
@@ -45,10 +44,6 @@ def main() -> None:
 
     setup()
 
-    from ubo_app.service import start_event_loop_thread, worker_thread
-
-    start_event_loop_thread(asyncio.get_event_loop())
-
     import headless_kivy.config
 
     from ubo_app.constants import (
@@ -80,6 +75,7 @@ def main() -> None:
 
     if not DISABLE_GRPC:
         from ubo_app.rpc.server import serve as grpc_serve
+        from ubo_app.service import worker_thread
 
         worker_thread.run_coroutine(grpc_serve())
 

--- a/ubo_app/setup.py
+++ b/ubo_app/setup.py
@@ -124,6 +124,10 @@ def setup() -> None:
             Fake(_Fake__return_value=Fake(_Fake__await_value=(Fake(), Fake()))),
         )
 
+        from ubo_app.utils import eeprom
+
+        eeprom.get_eeprom_data = lambda: {'speakers': {'model': 'wm8960'}}
+
         from ubo_app.utils import monitor_unit
 
         async def fake_monitor_unit(unit: str, callback: Callable[[str], None]) -> None:

--- a/ubo_app/setup.py
+++ b/ubo_app/setup.py
@@ -164,6 +164,10 @@ def setup() -> None:
 
     setup_ubo_gui()
 
+    from ubo_app.service import start_event_loop_thread
+
+    start_event_loop_thread(asyncio.new_event_loop())
+
 
 def clear_signal_handlers() -> None:
     """Clear the signal handlers."""

--- a/ubo_app/store/scheduler.py
+++ b/ubo_app/store/scheduler.py
@@ -76,12 +76,7 @@ class Scheduler(threading.Thread):
             0,
         )
         await asyncio.sleep(required_sleep)
-        try:
-            callback()
-        except Exception:
-            from ubo_app.logger import logger
-
-            logger.exception('Error in scheduler callback')
+        callback()
         if interval:
             self.tasks.add(
                 self.loop.create_task(

--- a/ubo_app/system/install.sh
+++ b/ubo_app/system/install.sh
@@ -140,7 +140,7 @@ else
 fi
 
 # Remove the Raspberry Pi's SSH daemon banner warning about setting a valid user
-sed -i '/^Banner /d' /etc/ssh/sshd_config.d/rename_user.conf
+sed -i '/^Banner /d' /etc/ssh/sshd_config.d/rename_user.conf || true
 
 # Set the ownership of the installation path
 chown -R $USERNAME:$USERNAME "$INSTALLATION_PATH"

--- a/ubo_app/utils/async_.py
+++ b/ubo_app/utils/async_.py
@@ -68,3 +68,12 @@ def to_thread(
     coroutine_runner = get_coroutine_runner()
 
     return coroutine_runner(asyncio.to_thread(task, *args, **kwargs))
+
+
+def to_thread_with_coroutine_runner(
+    task: Callable[T_params, T],
+    coroutine_runner: CoroutineRunner,
+    *args: T_params.args,
+    **kwargs: T_params.kwargs,
+) -> Handle:
+    return coroutine_runner(asyncio.to_thread(task, *args, **kwargs))

--- a/uv.lock
+++ b/uv.lock
@@ -1386,15 +1386,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/05/1b/ea40363be00560804
 
 [[package]]
 name = "pyright"
-version = "1.1.399"
+version = "1.1.400"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/9d/d91d5f6d26b2db95476fefc772e2b9a16d54c6bd0ea6bb5c1b6d635ab8b4/pyright-1.1.399.tar.gz", hash = "sha256:439035d707a36c3d1b443aec980bc37053fbda88158eded24b8eedcf1c7b7a1b", size = 3856954 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/cb/c306618a02d0ee8aed5fb8d0fe0ecfed0dbf075f71468f03a30b5f4e1fe0/pyright-1.1.400.tar.gz", hash = "sha256:b8a3ba40481aa47ba08ffb3228e821d22f7d391f83609211335858bf05686bdb", size = 3846546 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/b5/380380c9e7a534cb1783c70c3e8ac6d1193c599650a55838d0557586796e/pyright-1.1.399-py3-none-any.whl", hash = "sha256:55f9a875ddf23c9698f24208c764465ffdfd38be6265f7faf9a176e1dc549f3b", size = 5592584 },
+    { url = "https://files.pythonhosted.org/packages/c8/a5/5d285e4932cf149c90e3c425610c5efaea005475d5f96f1bfdb452956c62/pyright-1.1.400-py3-none-any.whl", hash = "sha256:c80d04f98b5a4358ad3a35e241dbf2a408eee33a40779df365644f8054d2517e", size = 5563460 },
 ]
 
 [[package]]
@@ -1551,15 +1551,15 @@ wheels = [
 
 [[package]]
 name = "python-redux"
-version = "0.22.2"
+version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-immutable" },
     { name = "python-strtobool" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/c4/b5ee17ac3d106b5f63be518b15cab8a686cd429af14ee1bc31e956955a25/python_redux-0.22.2.tar.gz", hash = "sha256:206e36b099a8d43fc86ac7ef5ca01a8fa7f88894bad874708633e4ae974162b9", size = 22057 }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b9/8c988abe28efd2c3ea1e878a23acb3d17783c3737ec40f92a0cb3117a0f6/python_redux-0.23.0.tar.gz", hash = "sha256:f4c74e5816536a9bb60380af146a103c25d28cc3eb21e9be8adeb7a72043e5e4", size = 21897 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/45/b29539d997d001ef6085219d38351d429c41490f5fac55d71bc57516a838/python_redux-0.22.2-py3-none-any.whl", hash = "sha256:9862312cc4e41ebc9577d252ad304f3d4c899a15c8a8b0c1f3c28fa4970f8a35", size = 28207 },
+    { url = "https://files.pythonhosted.org/packages/ec/48/b363307478a02f6489c6fdce30d42edc72cebc9e4965b85127dbc956cd17/python_redux-0.23.0-py3-none-any.whl", hash = "sha256:55db56abc58dc41d62da85d542c2a5995950f5e2530c14e4c02e51c5c0bc1c8c", size = 27542 },
 ]
 
 [[package]]
@@ -1684,27 +1684,27 @@ sdist = { url = "https://files.pythonhosted.org/packages/c0/1e/642208a685c5e96d3
 
 [[package]]
 name = "ruff"
-version = "0.11.0"
+version = "0.11.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/2b/7ca27e854d92df5e681e6527dc0f9254c9dc06c8408317893cf96c851cdd/ruff-0.11.0.tar.gz", hash = "sha256:e55c620690a4a7ee6f1cccb256ec2157dc597d109400ae75bbf944fc9d6462e2", size = 3799407 }
+sdist = { url = "https://files.pythonhosted.org/packages/52/f6/adcf73711f31c9f5393862b4281c875a462d9f639f4ccdf69dc368311c20/ruff-0.11.8.tar.gz", hash = "sha256:6d742d10626f9004b781f4558154bb226620a7242080e11caeffab1a40e99df8", size = 4086399 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/40/3d0340a9e5edc77d37852c0cd98c5985a5a8081fc3befaeb2ae90aaafd2b/ruff-0.11.0-py3-none-linux_armv6l.whl", hash = "sha256:dc67e32bc3b29557513eb7eeabb23efdb25753684b913bebb8a0c62495095acb", size = 10098158 },
-    { url = "https://files.pythonhosted.org/packages/ec/a9/d8f5abb3b87b973b007649ac7bf63665a05b2ae2b2af39217b09f52abbbf/ruff-0.11.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:38c23fd9bdec4eb437b4c1e3595905a0a8edfccd63a790f818b28c78fe345639", size = 10879071 },
-    { url = "https://files.pythonhosted.org/packages/ab/62/aaa198614c6211677913ec480415c5e6509586d7b796356cec73a2f8a3e6/ruff-0.11.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7c8661b0be91a38bd56db593e9331beaf9064a79028adee2d5f392674bbc5e88", size = 10247944 },
-    { url = "https://files.pythonhosted.org/packages/9f/52/59e0a9f2cf1ce5e6cbe336b6dd0144725c8ea3b97cac60688f4e7880bf13/ruff-0.11.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b6c0e8d3d2db7e9f6efd884f44b8dc542d5b6b590fc4bb334fdbc624d93a29a2", size = 10421725 },
-    { url = "https://files.pythonhosted.org/packages/a6/c3/dcd71acc6dff72ce66d13f4be5bca1dbed4db678dff2f0f6f307b04e5c02/ruff-0.11.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c3156d3f4b42e57247275a0a7e15a851c165a4fc89c5e8fa30ea6da4f7407b8", size = 9954435 },
-    { url = "https://files.pythonhosted.org/packages/a6/9a/342d336c7c52dbd136dee97d4c7797e66c3f92df804f8f3b30da59b92e9c/ruff-0.11.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:490b1e147c1260545f6d041c4092483e3f6d8eba81dc2875eaebcf9140b53905", size = 11492664 },
-    { url = "https://files.pythonhosted.org/packages/84/35/6e7defd2d7ca95cc385ac1bd9f7f2e4a61b9cc35d60a263aebc8e590c462/ruff-0.11.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1bc09a7419e09662983b1312f6fa5dab829d6ab5d11f18c3760be7ca521c9329", size = 12207856 },
-    { url = "https://files.pythonhosted.org/packages/22/78/da669c8731bacf40001c880ada6d31bcfb81f89cc996230c3b80d319993e/ruff-0.11.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bcfa478daf61ac8002214eb2ca5f3e9365048506a9d52b11bea3ecea822bb844", size = 11645156 },
-    { url = "https://files.pythonhosted.org/packages/ee/47/e27d17d83530a208f4a9ab2e94f758574a04c51e492aa58f91a3ed7cbbcb/ruff-0.11.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6fbb2aed66fe742a6a3a0075ed467a459b7cedc5ae01008340075909d819df1e", size = 13884167 },
-    { url = "https://files.pythonhosted.org/packages/9f/5e/42ffbb0a5d4b07bbc642b7d58357b4e19a0f4774275ca6ca7d1f7b5452cd/ruff-0.11.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92c0c1ff014351c0b0cdfdb1e35fa83b780f1e065667167bb9502d47ca41e6db", size = 11348311 },
-    { url = "https://files.pythonhosted.org/packages/c8/51/dc3ce0c5ce1a586727a3444a32f98b83ba99599bb1ebca29d9302886e87f/ruff-0.11.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e4fd5ff5de5f83e0458a138e8a869c7c5e907541aec32b707f57cf9a5e124445", size = 10305039 },
-    { url = "https://files.pythonhosted.org/packages/60/e0/475f0c2f26280f46f2d6d1df1ba96b3399e0234cf368cc4c88e6ad10dcd9/ruff-0.11.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:96bc89a5c5fd21a04939773f9e0e276308be0935de06845110f43fd5c2e4ead7", size = 9937939 },
-    { url = "https://files.pythonhosted.org/packages/e2/d3/3e61b7fd3e9cdd1e5b8c7ac188bec12975c824e51c5cd3d64caf81b0331e/ruff-0.11.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a9352b9d767889ec5df1483f94870564e8102d4d7e99da52ebf564b882cdc2c7", size = 10923259 },
-    { url = "https://files.pythonhosted.org/packages/30/32/cd74149ebb40b62ddd14bd2d1842149aeb7f74191fb0f49bd45c76909ff2/ruff-0.11.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:049a191969a10897fe052ef9cc7491b3ef6de79acd7790af7d7897b7a9bfbcb6", size = 11406212 },
-    { url = "https://files.pythonhosted.org/packages/00/ef/033022a6b104be32e899b00de704d7c6d1723a54d4c9e09d147368f14b62/ruff-0.11.0-py3-none-win32.whl", hash = "sha256:3191e9116b6b5bbe187447656f0c8526f0d36b6fd89ad78ccaad6bdc2fad7df2", size = 10310905 },
-    { url = "https://files.pythonhosted.org/packages/ed/8a/163f2e78c37757d035bd56cd60c8d96312904ca4a6deeab8442d7b3cbf89/ruff-0.11.0-py3-none-win_amd64.whl", hash = "sha256:c58bfa00e740ca0a6c43d41fb004cd22d165302f360aaa56f7126d544db31a21", size = 11411730 },
-    { url = "https://files.pythonhosted.org/packages/4e/f7/096f6efabe69b49d7ca61052fc70289c05d8d35735c137ef5ba5ef423662/ruff-0.11.0-py3-none-win_arm64.whl", hash = "sha256:868364fc23f5aa122b00c6f794211e85f7e78f5dffdf7c590ab90b8c4e69b657", size = 10538956 },
+    { url = "https://files.pythonhosted.org/packages/9f/60/c6aa9062fa518a9f86cb0b85248245cddcd892a125ca00441df77d79ef88/ruff-0.11.8-py3-none-linux_armv6l.whl", hash = "sha256:896a37516c594805e34020c4a7546c8f8a234b679a7716a3f08197f38913e1a3", size = 10272473 },
+    { url = "https://files.pythonhosted.org/packages/a0/e4/0325e50d106dc87c00695f7bcd5044c6d252ed5120ebf423773e00270f50/ruff-0.11.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ab86d22d3d721a40dd3ecbb5e86ab03b2e053bc93c700dc68d1c3346b36ce835", size = 11040862 },
+    { url = "https://files.pythonhosted.org/packages/e6/27/b87ea1a7be37fef0adbc7fd987abbf90b6607d96aa3fc67e2c5b858e1e53/ruff-0.11.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:258f3585057508d317610e8a412788cf726efeefa2fec4dba4001d9e6f90d46c", size = 10385273 },
+    { url = "https://files.pythonhosted.org/packages/d3/f7/3346161570d789045ed47a86110183f6ac3af0e94e7fd682772d89f7f1a1/ruff-0.11.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:727d01702f7c30baed3fc3a34901a640001a2828c793525043c29f7614994a8c", size = 10578330 },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/327fb950b4763c7b3784f91d3038ef10c13b2d42322d4ade5ce13a2f9edb/ruff-0.11.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3dca977cc4fc8f66e89900fa415ffe4dbc2e969da9d7a54bfca81a128c5ac219", size = 10122223 },
+    { url = "https://files.pythonhosted.org/packages/de/c7/ba686bce9adfeb6c61cb1bbadc17d58110fe1d602f199d79d4c880170f19/ruff-0.11.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c657fa987d60b104d2be8b052d66da0a2a88f9bd1d66b2254333e84ea2720c7f", size = 11697353 },
+    { url = "https://files.pythonhosted.org/packages/53/8e/a4fb4a1ddde3c59e73996bb3ac51844ff93384d533629434b1def7a336b0/ruff-0.11.8-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f2e74b021d0de5eceb8bd32919f6ff8a9b40ee62ed97becd44993ae5b9949474", size = 12375936 },
+    { url = "https://files.pythonhosted.org/packages/ad/a1/9529cb1e2936e2479a51aeb011307e7229225df9ac64ae064d91ead54571/ruff-0.11.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f9b5ef39820abc0f2c62111f7045009e46b275f5b99d5e59dda113c39b7f4f38", size = 11850083 },
+    { url = "https://files.pythonhosted.org/packages/3e/94/8f7eac4c612673ae15a4ad2bc0ee62e03c68a2d4f458daae3de0e47c67ba/ruff-0.11.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c1dba3135ca503727aa4648152c0fa67c3b1385d3dc81c75cd8a229c4b2a1458", size = 14005834 },
+    { url = "https://files.pythonhosted.org/packages/1e/7c/6f63b46b2be870cbf3f54c9c4154d13fac4b8827f22fa05ac835c10835b2/ruff-0.11.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f024d32e62faad0f76b2d6afd141b8c171515e4fb91ce9fd6464335c81244e5", size = 11503713 },
+    { url = "https://files.pythonhosted.org/packages/3a/91/57de411b544b5fe072779678986a021d87c3ee5b89551f2ca41200c5d643/ruff-0.11.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d365618d3ad747432e1ae50d61775b78c055fee5936d77fb4d92c6f559741948", size = 10457182 },
+    { url = "https://files.pythonhosted.org/packages/01/49/cfe73e0ce5ecdd3e6f1137bf1f1be03dcc819d1bfe5cff33deb40c5926db/ruff-0.11.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4d9aaa91035bdf612c8ee7266153bcf16005c7c7e2f5878406911c92a31633cb", size = 10101027 },
+    { url = "https://files.pythonhosted.org/packages/56/21/a5cfe47c62b3531675795f38a0ef1c52ff8de62eaddf370d46634391a3fb/ruff-0.11.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0eba551324733efc76116d9f3a0d52946bc2751f0cd30661564117d6fd60897c", size = 11111298 },
+    { url = "https://files.pythonhosted.org/packages/36/98/f76225f87e88f7cb669ae92c062b11c0a1e91f32705f829bd426f8e48b7b/ruff-0.11.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:161eb4cff5cfefdb6c9b8b3671d09f7def2f960cee33481dd898caf2bcd02304", size = 11566884 },
+    { url = "https://files.pythonhosted.org/packages/de/7e/fff70b02e57852fda17bd43f99dda37b9bcf3e1af3d97c5834ff48d04715/ruff-0.11.8-py3-none-win32.whl", hash = "sha256:5b18caa297a786465cc511d7f8be19226acf9c0a1127e06e736cd4e1878c3ea2", size = 10451102 },
+    { url = "https://files.pythonhosted.org/packages/7b/a9/eaa571eb70648c9bde3120a1d5892597de57766e376b831b06e7c1e43945/ruff-0.11.8-py3-none-win_amd64.whl", hash = "sha256:6e70d11043bef637c5617297bdedec9632af15d53ac1e1ba29c448da9341b0c4", size = 11597410 },
+    { url = "https://files.pythonhosted.org/packages/cd/be/f6b790d6ae98f1f32c645f8540d5c96248b72343b0a56fab3a07f2941897/ruff-0.11.8-py3-none-win_arm64.whl", hash = "sha256:304432e4c4a792e3da85b7699feb3426a0908ab98bf29df22a31b0cdd098fac2", size = 10713129 },
 ]
 
 [[package]]
@@ -1983,7 +1983,7 @@ requires-dist = [
     { name = "python-debouncer", specifier = ">=0.1.5" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-fake", specifier = ">=0.2.0" },
-    { name = "python-redux", specifier = ">=0.22.2" },
+    { name = "python-redux", specifier = ">=0.23.0" },
     { name = "python-strtobool", specifier = ">=1.0.0" },
     { name = "pyzbar", specifier = ">=0.1.9" },
     { name = "quart", specifier = ">=0.19.6" },
@@ -2008,7 +2008,7 @@ dev = [
     { name = "pdbpp", specifier = ">=0.10.3" },
     { name = "poethepoet", specifier = ">=0.24.4" },
     { name = "pyfakefs", specifier = ">=5.7.4" },
-    { name = "pyright", specifier = ">=1.1.399" },
+    { name = "pyright", specifier = ">=1.1.400" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
@@ -2016,7 +2016,7 @@ dev = [
     { name = "pytest-repeat", specifier = ">=0.9.3" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "pytest-xdist", specifier = ">=3.5.0" },
-    { name = "ruff", specifier = ">=0.10.0" },
+    { name = "ruff", specifier = ">=0.11.8" },
     { name = "toml", specifier = ">=0.10.2" },
 ]
 


### PR DESCRIPTION
Use the new `StoreOptions.autorun_class` of `python-redux` to make sure they run in the service thread they were defined in.