### PR TITLE
Fix lazy loading for Piper TTS and Vosk models to enable first-time setup

### DIFF
--- a/tests/store/test_vosk_engine_lazy_load.py
+++ b/tests/store/test_vosk_engine_lazy_load.py
@@ -1,0 +1,108 @@
+"""Lazy-load regression test for the core Vosk speech-recognition engine.
+
+On first-time setup the Vosk model is downloaded *after* the engine has already
+started (``is_intents_active`` defaults to ``True``, so the wake-word engine
+runs at boot). The engine must not require the model at loop start — an eager
+``Model(...)`` load crashes the background task and nothing reliably restarts it
+once the download finishes, leaving recognition dead until an app restart.
+Instead ``_run`` reconciles before each chunk and builds the recognizer the
+moment the model lands on disk.
+
+Loads ``vosk_engine.py`` via ``importlib`` (like ``test_mic_buffer.py``) and
+drives ``VoskEngine._reconcile`` against a minimal stand-in ``self`` — it only
+touches ``self.grammar_lock`` and ``self._phrases`` — so the test needs neither
+real Vosk nor a fully constructed engine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    import pytest
+
+SERVICE_PATH = Path(__file__).parents[2] / 'ubo_app/services/090-speech-recognition'
+
+
+def _load_vosk_engine(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Load ``vosk_engine.py`` in isolation, returning the module object."""
+    monkeypatch.syspath_prepend(SERVICE_PATH.as_posix())
+    spec = importlib.util.spec_from_file_location(
+        'vosk_engine_test_module',
+        SERVICE_PATH / 'vosk_engine.py',
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_fake_vosk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the real ``vosk`` module so model loads return cheap sentinels."""
+    fake = types.ModuleType('vosk')
+    fake.Model = lambda **_kwargs: SimpleNamespace(kind='model')  # pyright: ignore[reportAttributeAccessIssue]
+    fake.KaldiRecognizer = lambda *_args: SimpleNamespace(kind='recognizer')  # pyright: ignore[reportAttributeAccessIssue]
+    monkeypatch.setitem(sys.modules, 'vosk', fake)
+
+
+async def test_reconcile_waits_then_self_heals_when_model_appears(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """No recognizer while the model is missing; built once it's downloaded."""
+    module = _load_vosk_engine(monkeypatch)
+    _install_fake_vosk(monkeypatch)
+    monkeypatch.setattr(module, '_read_selected_model', lambda: 'm1')
+    monkeypatch.setattr(module, 'model_path_for', lambda model_id: tmp_path / model_id)
+
+    engine = SimpleNamespace(
+        grammar_lock=asyncio.Lock(),
+        _phrases=('okay ubo', '[unk]'),
+    )
+    state = module._RecognizerState(  # noqa: SLF001
+        model=None,
+        recognizer=None,
+        model_id=None,
+        phrases=None,
+    )
+
+    # Model not downloaded yet: engine stays unloaded, no crash.
+    state = await module.VoskEngine._reconcile(engine, state)  # noqa: SLF001
+    assert state.recognizer is None
+    assert state.model_id == 'm1'
+
+    # Download lands on disk: the next reconcile builds the recognizer with no
+    # app restart — the core of the fix.
+    (tmp_path / 'm1').mkdir()
+    state = await module.VoskEngine._reconcile(engine, state)  # noqa: SLF001
+    assert state.recognizer is not None
+    assert state.model is not None
+    assert state.model_id == 'm1'
+
+
+async def test_reconcile_keeps_waiting_while_model_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Repeated reconciles with an absent model never build a recognizer."""
+    module = _load_vosk_engine(monkeypatch)
+    _install_fake_vosk(monkeypatch)
+    monkeypatch.setattr(module, '_read_selected_model', lambda: 'absent')
+    monkeypatch.setattr(module, 'model_path_for', lambda model_id: tmp_path / model_id)
+
+    engine = SimpleNamespace(grammar_lock=asyncio.Lock(), _phrases=None)
+    state = module._RecognizerState(None, None, None, None)  # noqa: SLF001
+
+    for _ in range(3):
+        state = await module.VoskEngine._reconcile(engine, state)  # noqa: SLF001
+        assert state.recognizer is None

--- a/tests/store/test_vosk_engine_lazy_load.py
+++ b/tests/store/test_vosk_engine_lazy_load.py
@@ -72,22 +72,26 @@ async def test_reconcile_waits_then_self_heals_when_model_appears(
     state = module._RecognizerState(  # noqa: SLF001
         model=None,
         recognizer=None,
-        model_id=None,
+        loaded_model_id=None,
         phrases=None,
+        retry_at=0.0,
     )
 
-    # Model not downloaded yet: engine stays unloaded, no crash.
+    # Model not downloaded yet: engine stays unloaded, no crash, and
+    # ``loaded_model_id`` does NOT advance so the model keeps being retried.
     state = await module.VoskEngine._reconcile(engine, state)  # noqa: SLF001
     assert state.recognizer is None
-    assert state.model_id == 'm1'
+    assert state.loaded_model_id is None
 
     # Download lands on disk: the next reconcile builds the recognizer with no
-    # app restart — the core of the fix.
+    # app restart — the core of the fix. Reset ``retry_at`` to bypass the
+    # back-off throttle (a wall-clock second would otherwise have to elapse).
     (tmp_path / 'm1').mkdir()
+    state = state._replace(retry_at=0.0)
     state = await module.VoskEngine._reconcile(engine, state)  # noqa: SLF001
     assert state.recognizer is not None
     assert state.model is not None
-    assert state.model_id == 'm1'
+    assert state.loaded_model_id == 'm1'
 
 
 async def test_reconcile_keeps_waiting_while_model_absent(
@@ -101,8 +105,54 @@ async def test_reconcile_keeps_waiting_while_model_absent(
     monkeypatch.setattr(module, 'model_path_for', lambda model_id: tmp_path / model_id)
 
     engine = SimpleNamespace(grammar_lock=asyncio.Lock(), _phrases=None)
-    state = module._RecognizerState(None, None, None, None)  # noqa: SLF001
+    state = module._RecognizerState(None, None, None, None, 0.0)  # noqa: SLF001
 
     for _ in range(3):
+        # Reset the back-off each iteration so every pass actually re-attempts
+        # the load (instead of being throttled out).
+        state = state._replace(retry_at=0.0)
         state = await module.VoskEngine._reconcile(engine, state)  # noqa: SLF001
         assert state.recognizer is None
+        assert state.loaded_model_id is None
+
+
+async def test_reconcile_retries_switched_model_without_abandoning_it(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Switching to a not-ready model keeps retrying it, not silently stuck.
+
+    Regression guard for the bug where ``loaded_model_id`` advanced to a
+    not-yet-ready model, so the previous recognizer lingered and the new model
+    was never loaded once it finished downloading.
+    """
+    module = _load_vosk_engine(monkeypatch)
+    _install_fake_vosk(monkeypatch)
+    monkeypatch.setattr(module, 'model_path_for', lambda model_id: tmp_path / model_id)
+
+    engine = SimpleNamespace(grammar_lock=asyncio.Lock(), _phrases=None)
+
+    # Start with model 'a' already loaded; the user then selects 'b' (absent).
+    previous_recognizer = SimpleNamespace(kind='recognizer-a')
+    state = module._RecognizerState(  # noqa: SLF001
+        model=SimpleNamespace(kind='model-a'),
+        recognizer=previous_recognizer,
+        loaded_model_id='a',
+        phrases=None,
+        retry_at=0.0,
+    )
+    monkeypatch.setattr(module, '_read_selected_model', lambda: 'b')
+
+    # 'b' isn't on disk yet: keep the working recognizer, do NOT advance
+    # loaded_model_id (so 'b' keeps being retried).
+    state = state._replace(retry_at=0.0)
+    state = await module.VoskEngine._reconcile(engine, state)  # noqa: SLF001
+    assert state.recognizer is previous_recognizer
+    assert state.loaded_model_id == 'a'
+
+    # 'b' finishes downloading: the retry loads it.
+    (tmp_path / 'b').mkdir()
+    state = state._replace(retry_at=0.0)
+    state = await module.VoskEngine._reconcile(engine, state)  # noqa: SLF001
+    assert state.recognizer is not previous_recognizer
+    assert state.loaded_model_id == 'b'

--- a/ubo_app/engines/abstraction/background_running_mixin.py
+++ b/ubo_app/engines/abstraction/background_running_mixin.py
@@ -32,6 +32,13 @@ class BackgroundRunningMixin(EngineMixin, abc.ABC):
     def _task_done_callback(self, task: asyncio.Task[None]) -> None:
         self._is_running = False
         self._task = None
+        logger.debug(
+            'Engine run task finished',
+            extra={
+                'engine_name': self.name,
+                'cancelled': task.cancelled(),
+            },
+        )
         if not task.cancelled() and task.exception():
             logger.exception(
                 'An error occurred while running the engine',
@@ -69,6 +76,10 @@ class BackgroundRunningMixin(EngineMixin, abc.ABC):
             if self._is_running:
                 return True
             self._is_running = True
+            logger.debug(
+                'Starting engine run task',
+                extra={'engine_name': self.name},
+            )
             create_task(
                 self._run(),
                 callback=self._set_task,
@@ -90,7 +101,16 @@ class BackgroundRunningMixin(EngineMixin, abc.ABC):
     @final
     def decide_running_state(self) -> None:
         """Decide whether the engine should be running based on the state."""
-        if self.should_be_running():
+        should_be_running = self.should_be_running()
+        logger.debug(
+            'Deciding engine running state',
+            extra={
+                'engine_name': self.name,
+                'should_be_running': should_be_running,
+                'is_running': self._is_running,
+            },
+        )
+        if should_be_running:
             self.run()
         else:
             self.stop()

--- a/ubo_app/services/090-assistant/ubo-service/tests/test_pipecat_debug.py
+++ b/ubo_app/services/090-assistant/ubo-service/tests/test_pipecat_debug.py
@@ -19,11 +19,22 @@ from ubo_assistant.pipecat_debug import (
 
 
 class FakeWhiskerServer:
-    """Fake Whisker 2.0 sink that records its file_name."""
+    """Fake Whisker 2.0 WS-server sink (used when no file path is given)."""
 
     calls: ClassVar[list[str | None]] = []
 
     def __init__(self, *, file_name: str | None = None, **_kwargs: object) -> None:
+        """Record construction of the WS-server sink."""
+        self.file_name = file_name
+        self.calls.append(file_name)
+
+
+class FakeWhiskerFile:
+    """Fake Whisker 2.0 file sink that records its file_name."""
+
+    calls: ClassVar[list[str | None]] = []
+
+    def __init__(self, file_name: str | None = None, **_kwargs: object) -> None:
         """Record the configured sink file name."""
         self.file_name = file_name
         self.calls.append(file_name)
@@ -46,6 +57,7 @@ class FakeWhiskerModule(types.ModuleType):
 
     WhiskerObserver = FakeWhiskerObserver
     WhiskerServer = FakeWhiskerServer
+    WhiskerFile = FakeWhiskerFile
 
 
 class FakeTask:
@@ -68,6 +80,7 @@ class PipecatDebugTests(unittest.TestCase):
         """Reset fake observer state before each test."""
         FakeWhiskerObserver.calls = []
         FakeWhiskerServer.calls = []
+        FakeWhiskerFile.calls = []
 
     def test_whisker_is_disabled_by_default(self) -> None:
         """Whisker is opt-in and does not require the dependency when disabled."""
@@ -122,7 +135,9 @@ class PipecatDebugTests(unittest.TestCase):
         self.assertEqual(len(FakeWhiskerObserver.calls), 1)  # noqa: PT009
         worker, _sink = FakeWhiskerObserver.calls[0]
         self.assertIs(worker, task)  # noqa: PT009
+        # No file path → the WS-server sink is used, not the file sink.
         self.assertEqual(FakeWhiskerServer.calls, [None])  # noqa: PT009
+        self.assertEqual(FakeWhiskerFile.calls, [])  # noqa: PT009
 
     def test_attach_whisker_observer_passes_file_name(self) -> None:
         """The optional session file path is passed to Whisker."""
@@ -145,8 +160,10 @@ class PipecatDebugTests(unittest.TestCase):
                     attach_whisker_observer(cast('SupportsWhiskerObserver', task)),
                 )
 
-            # Whisker 2.0 passes the file path to the sink, not the observer.
-            self.assertEqual(FakeWhiskerServer.calls, [whisker_file])  # noqa: PT009
+            # Whisker 2.0: a file path selects the file sink (not the WS
+            # server), and the path goes to the sink, not the observer.
+            self.assertEqual(FakeWhiskerFile.calls, [whisker_file])  # noqa: PT009
+            self.assertEqual(FakeWhiskerServer.calls, [])  # noqa: PT009
             self.assertEqual(len(FakeWhiskerObserver.calls), 1)  # noqa: PT009
 
 

--- a/ubo_app/services/090-assistant/ubo-service/tests/test_piper_tts.py
+++ b/ubo_app/services/090-assistant/ubo-service/tests/test_piper_tts.py
@@ -1,0 +1,135 @@
+"""Regression tests for Piper TTS first-time setup.
+
+Bug: on first-time setup the default Piper voice isn't on disk yet (it's
+downloaded on demand). Previously ``PiperTTSService.__init__`` eagerly loaded
+the model and raised, so ``UboTTSService.piper_tts`` became ``None``. Pipecat
+1.0 freezes the switcher's service list at construction, so a ``None`` Piper
+slot is dropped from ``service_map`` forever — selecting Piper fell through to
+the no-op and stayed silent until the app was restarted (after which the file
+existed and the load succeeded).
+
+These tests pin the fix: the service constructs without the model on disk,
+stays a selectable switch target, and loads the voice lazily once downloaded.
+``DATA_PATH`` is pointed at an empty temp dir so first-time setup is simulated
+deterministically with no network and no real model.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, TypeVar, cast
+from unittest.mock import MagicMock, patch
+
+import ubo_assistant.piper as piper_module
+from ubo_assistant.piper import DEFAULT_PIPER_VOICE_ID, PiperTTSService, _voice_path
+from ubo_assistant.ubo_tts import TTSServiceConfig, UboTTSService
+
+if TYPE_CHECKING:
+    from ubo_bindings.client import UboRPCClient
+
+F = TypeVar('F', bound=Callable[..., object])
+
+
+class FakeClient:
+    """Minimal client surface used by the switcher under test."""
+
+    def dispatch(self, *, action: object) -> None:
+        """Ignore dispatched assistance reports."""
+        _ = action
+
+    def autorun(self, selectors: list[str]) -> Callable[[F], F]:
+        """Return a decorator without invoking it (no autoruns in tests)."""
+        _ = selectors
+
+        def decorator(function: F) -> F:
+            return function
+
+        return decorator
+
+
+class PiperFirstTimeSetupTests(unittest.IsolatedAsyncioTestCase):
+    """Piper must survive (and stay selectable) before its model is downloaded."""
+
+    async def test_constructs_without_model_file(self) -> None:
+        """PiperTTSService must not raise when the voice file is absent."""
+        with tempfile.TemporaryDirectory() as tmp, patch.object(
+            piper_module,
+            'DATA_PATH',
+            Path(tmp),
+        ):
+            service = PiperTTSService(voice_id=DEFAULT_PIPER_VOICE_ID)
+
+            self.assertIsNone(service._client)  # noqa: PT009, SLF001
+            self.assertIsNone(service._loaded_voice_id)  # noqa: PT009, SLF001
+            self.assertEqual(  # noqa: PT009
+                service._requested_voice_id,  # noqa: SLF001
+                DEFAULT_PIPER_VOICE_ID,
+            )
+
+    async def test_piper_stays_selectable_in_switcher_without_model(self) -> None:
+        """Selecting Piper before download must switch to Piper, not the no-op."""
+        with tempfile.TemporaryDirectory() as tmp, patch.object(
+            piper_module,
+            'DATA_PATH',
+            Path(tmp),
+        ):
+            switcher = UboTTSService(
+                client=cast('UboRPCClient', FakeClient()),
+                config=TTSServiceConfig(),
+                google_credentials=None,
+                selector='state.assistant.selected_tts',
+            )
+
+            # The Piper slot is a real service, not dropped from the map.
+            self.assertIsNotNone(switcher.piper_tts)  # noqa: PT009
+            self.assertIn('piper', switcher.service_map)  # noqa: PT009
+
+            await switcher.set_selected_service('piper')
+
+            self.assertIs(  # noqa: PT009
+                switcher.selected_service,
+                switcher.piper_tts,
+            )
+            self.assertEqual(  # noqa: PT009
+                switcher._current_service_id,  # noqa: SLF001
+                'piper',
+            )
+            self.assertIsNot(  # noqa: PT009
+                switcher.strategy.active_service,
+                switcher._noop_service,  # noqa: SLF001
+            )
+
+    async def test_voice_loads_lazily_once_downloaded(self) -> None:
+        """A voice downloaded after construction loads on the next utterance."""
+        with tempfile.TemporaryDirectory() as tmp, patch.object(
+            piper_module,
+            'DATA_PATH',
+            Path(tmp),
+        ):
+            service = PiperTTSService(voice_id=DEFAULT_PIPER_VOICE_ID)
+            self.assertIsNone(service._client)  # noqa: PT009, SLF001
+
+            # Simulate the core process finishing the download.
+            model_path = _voice_path(DEFAULT_PIPER_VOICE_ID)
+            model_path.parent.mkdir(parents=True, exist_ok=True)
+            model_path.touch()
+
+            fake_voice = MagicMock()
+            fake_voice.config.sample_rate = 22050
+
+            service.request_voice(DEFAULT_PIPER_VOICE_ID)
+            with patch('piper.voice.PiperVoice.load', return_value=fake_voice):
+                await service._ensure_voice_loaded()  # noqa: SLF001
+
+            self.assertIs(service._client, fake_voice)  # noqa: PT009, SLF001
+            self.assertEqual(  # noqa: PT009
+                service._loaded_voice_id,  # noqa: SLF001
+                DEFAULT_PIPER_VOICE_ID,
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ubo_app/services/090-assistant/ubo-service/ubo_assistant/piper.py
+++ b/ubo_app/services/090-assistant/ubo-service/ubo_assistant/piper.py
@@ -29,6 +29,12 @@ if TYPE_CHECKING:
 
 DEFAULT_PIPER_VOICE_ID = 'en/en_US/kristin/medium/en_US-kristin-medium'
 
+# Placeholder sample rate used before any voice model is loaded. Piper
+# "medium"/"high" voices (including the default ``kristin/medium``) are
+# 22050 Hz; ``_ensure_voice_loaded`` overwrites ``_sample_rate`` from the real
+# model the moment one is loaded, so this only applies pre-first-load.
+_DEFAULT_SAMPLE_RATE = 22050
+
 
 def _voice_path(voice_id: str) -> Path:
     """Build the on-disk path for *voice_id*'s ``.onnx`` model file."""
@@ -77,9 +83,22 @@ class PiperTTSService(TTSService):
         # ``run_tts`` reconciles the two before every utterance, so a
         # missed signal or a not-yet-downloaded voice self-heals on the
         # next turn instead of needing the user to toggle repeatedly.
+        #
+        # The model is loaded lazily: when the voice file isn't on disk yet
+        # (first-time setup — the core process downloads it on demand) we
+        # construct with no client and ``_loaded_voice_id = None``. Keeping
+        # this service alive (rather than failing construction) is what lets
+        # the switcher list it as a selectable target; ``_ensure_voice_loaded``
+        # then loads the model before the first utterance once it's downloaded,
+        # so the user never has to restart the app.
         self._requested_voice_id = voice_id
-        self._loaded_voice_id = voice_id
-        self._client = PiperVoice.load(_voice_path(voice_id))
+        self._loaded_voice_id: str | None = None
+        self._client: PiperVoice | None = None
+        sample_rate = _DEFAULT_SAMPLE_RATE
+        if _voice_path(voice_id).exists():
+            self._client = PiperVoice.load(_voice_path(voice_id))
+            self._loaded_voice_id = voice_id
+            sample_rate = self._client.config.sample_rate
 
         self.tasks: list[asyncio.Handle] = []
 
@@ -91,7 +110,7 @@ class PiperTTSService(TTSService):
             push_silence_after_stop=push_silence_after_stop,
             silence_time_s=silence_time_s,
             pause_frame_processing=pause_frame_processing,
-            sample_rate=self._client.config.sample_rate,
+            sample_rate=sample_rate,
             text_filters=text_filters,
             transport_destination=transport_destination,
             settings=TTSSettings(
@@ -166,6 +185,14 @@ class PiperTTSService(TTSService):
 
     def synthesize(self, text: str) -> None:
         """Synthesize audio from text."""
+        if self._client is None:
+            # No voice loaded yet (none downloaded). Signal end-of-stream so
+            # the consumer in ``run_tts`` doesn't block on the queue.
+            self.get_event_loop().call_soon_threadsafe(
+                self.create_task,
+                self._sample_queue.put(None),
+            )
+            return
         for audio_chunk in self._client.synthesize(text=text):
             if audio_chunk:
                 sample = audio_chunk.audio_int16_bytes
@@ -208,6 +235,18 @@ class PiperTTSService(TTSService):
                 # utterance uses the requested voice (or the current one
                 # if the new model isn't downloaded yet).
                 await self._ensure_voice_loaded()
+
+                if self._client is None:
+                    # Piper is selected but no voice has been downloaded yet.
+                    # End the turn quietly; the next utterance retries once the
+                    # core process has fetched the model.
+                    logger.warning(
+                        'Piper selected but no voice downloaded yet; '
+                        'skipping synthesis',
+                        extra={'requested_voice_id': self._requested_voice_id},
+                    )
+                    yield TTSStoppedFrame()
+                    return
 
                 self.get_event_loop().run_in_executor(
                     self._process_executor,

--- a/ubo_app/services/090-assistant/ubo-service/ubo_assistant/ubo_tts.py
+++ b/ubo_app/services/090-assistant/ubo-service/ubo_assistant/ubo_tts.py
@@ -201,10 +201,14 @@ class UboTTSService(UboSwitchService[TTSService], TTSService):
         self.rime_tts = GenericTTSProxy()
         self.venice_tts = GenericTTSProxy()
 
-        # Initialize Piper TTS with the default voice — the store autorun
-        # registered in `_ensure_autoruns_started` reconciles it to the
-        # user's persisted voice (it fires once on subscription with the
-        # current value, then on every change).
+        # Initialize Piper TTS. The model loads lazily: PiperTTSService
+        # constructs even when no voice is on disk yet (first-time setup), so
+        # this slot is never None and Piper always stays a selectable target in
+        # the switcher's frozen init list. The store autorun registered in
+        # `_ensure_autoruns_started` reconciles it to the user's persisted
+        # voice (firing once on subscription, then on every change), and
+        # `PiperTTSService.run_tts` loads the requested voice before the first
+        # utterance — so a freshly-downloaded voice works without a restart.
         self.piper_tts = self._initialize_service(
             'Piper',
             lambda: PiperTTSService(voice_id=DEFAULT_PIPER_VOICE_ID)

--- a/ubo_app/services/090-speech-recognition/abstraction/wake_word_recognition_mixin.py
+++ b/ubo_app/services/090-speech-recognition/abstraction/wake_word_recognition_mixin.py
@@ -30,6 +30,15 @@ class WakeWordRecognitionMixin(BaseSpeechRecognitionEngine, abc.ABC):
 
     def set_wake_words(self, wake_words: Sequence[str] | None) -> None:
         """Set the wake words for detection."""
+        from ubo_app.logger import logger
+
+        logger.debug(
+            'Setting wake words',
+            extra={
+                'engine_name': self.name,
+                'wake_words': list(wake_words) if wake_words else None,
+            },
+        )
         self.wake_words = wake_words
 
         self.decide_running_state()

--- a/ubo_app/services/090-speech-recognition/vosk_engine.py
+++ b/ubo_app/services/090-speech-recognition/vosk_engine.py
@@ -7,6 +7,7 @@ import json
 from asyncio import get_event_loop
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
 
 from abstraction.speech_recognition_mixin import (
     PhraseRecognition,
@@ -26,10 +27,46 @@ from ubo_app.store.services.speech_recognition import (
 )
 from ubo_app.utils import IS_RPI
 
+if TYPE_CHECKING:
+    from vosk import KaldiRecognizer, Model
+
 
 @store.with_state(lambda state: state.assistant.selected_vosk_model)
 def _read_selected_model(selected_model: str) -> str:
     return selected_model or DEFAULT_VOSK_MODEL_ID
+
+
+class _RecognizerState(NamedTuple):
+    """The loaded Vosk model/recognizer and what they were built for."""
+
+    model: Model | None
+    recognizer: KaldiRecognizer | None
+    model_id: str | None
+    phrases: tuple[str, ...] | None
+
+
+def _load_model(model_id: str) -> Model | None:
+    """Load the Vosk model if it's on disk, else None (not downloaded yet)."""
+    from vosk import Model
+
+    model_dir = Path(str(model_path_for(model_id)))
+    if not model_dir.exists():
+        return None
+    return Model(model_path=model_dir.resolve().as_posix())
+
+
+def _make_recognizer(
+    model: Model,
+    phrases: tuple[str, ...] | None,
+) -> KaldiRecognizer:
+    """Build a recognizer for *model*, limited to *phrases* when provided."""
+    from vosk import KaldiRecognizer
+
+    return KaldiRecognizer(
+        model,
+        SPEECH_RECOGNITION_FRAME_RATE,
+        *([json.dumps(phrases)] if phrases else []),
+    )
 
 
 class VoskEngine(
@@ -46,32 +83,93 @@ class VoskEngine(
 
         super().__init__(label='Vosk')
 
+    async def _reconcile(self, state: _RecognizerState) -> _RecognizerState:
+        """Reconcile the recognizer with the selected model and phrases.
+
+        The model is loaded lazily: while the selected model isn't on disk yet
+        (first-time setup, download in progress) the returned state carries
+        ``recognizer=None`` and ``_run`` drops audio. The recognizer is built
+        the moment the model appears on disk, so a model downloaded at runtime
+        self-heals on the next chunk — no app restart, unlike an eager load that
+        would crash the engine at boot when the model is still missing.
+        """
+        async with self.grammar_lock:
+            requested_model_id = _read_selected_model()
+            phrases = self._phrases
+            model = state.model
+            recognizer = state.recognizer
+
+            if requested_model_id != state.model_id or recognizer is None:
+                model_changed = requested_model_id != state.model_id
+                new_model = _load_model(requested_model_id)
+                if new_model is not None:
+                    logger.debug(
+                        'Vosk - Loaded model',
+                        extra={'model_id': requested_model_id},
+                    )
+                    return _RecognizerState(
+                        new_model,
+                        _make_recognizer(new_model, phrases),
+                        requested_model_id,
+                        phrases,
+                    )
+                if recognizer is not None:
+                    # Switched to a not-yet-downloaded model; keep the working
+                    # one rather than going silent.
+                    logger.warning(
+                        'Vosk - Requested model not on disk, staying on '
+                        'previous model',
+                        extra={'model_id': requested_model_id},
+                    )
+                elif model_changed:
+                    logger.debug(
+                        'Vosk - Selected model not on disk yet; waiting for '
+                        'download',
+                        extra={'model_id': requested_model_id},
+                    )
+                return state._replace(model_id=requested_model_id)
+
+            if phrases != state.phrases and model is not None:
+                logger.debug('Vosk - Updating phrases', extra={'new_phrases': phrases})
+                if IS_RPI:
+                    recognizer.Reset()
+                    recognizer.SetGrammar(json.dumps(phrases))
+                    return state._replace(phrases=phrases)
+                return state._replace(
+                    recognizer=_make_recognizer(model, phrases),
+                    phrases=phrases,
+                )
+
+            return state
+
     @override
     async def _run(self) -> None:
-        from vosk import KaldiRecognizer, Model
-
-        phrases = self._phrases
-        current_model_id = _read_selected_model()
-        model_dir = Path(str(model_path_for(current_model_id)))
-        model = Model(
-            model_path=model_dir.resolve().as_posix(),
-        )
+        # The model is loaded lazily and reconciled before each chunk (see
+        # ``_reconcile``): on first-time setup the selected model isn't on disk
+        # yet (the core downloads it on demand). An eager load here would crash
+        # the engine at boot, and nothing reliably restarts it once the download
+        # finishes, leaving recognition dead until an app restart. Instead the
+        # loop stays alive with no recognizer, drops audio while the model is
+        # missing, and builds the recognizer the moment it appears — so a model
+        # downloaded at runtime self-heals on the next audio chunk.
         logger.debug(
             'Vosk - Starting recognition loop',
-            extra={
-                'engine_name': self.name,
-                'phrases': phrases,
-                'model_id': current_model_id,
-            },
+            extra={'engine_name': self.name},
         )
-        recognizer = KaldiRecognizer(
-            model,
-            SPEECH_RECOGNITION_FRAME_RATE,
-            *([json.dumps(phrases)] if phrases else []),
+        state = _RecognizerState(
+            model=None,
+            recognizer=None,
+            model_id=None,
+            phrases=None,
         )
 
         while self.should_be_running():
             data = await self.input_queue.get()
+
+            state = await self._reconcile(state)
+            recognizer = state.recognizer
+            if recognizer is None:
+                continue
 
             if await get_event_loop().run_in_executor(
                 self.process_executor,
@@ -79,7 +177,6 @@ class VoskEngine(
                 data,
             ):
                 result = json.loads(recognizer.FinalResult())
-
                 if result.get('text'):
                     await self.report(result=result['text'])
             else:
@@ -100,51 +197,6 @@ class VoskEngine(
 
             if self.ongoing_recognition is not None:
                 self.ongoing_recognition.append_voice(data)
-
-            async with self.grammar_lock:
-                requested_model_id = _read_selected_model()
-                if requested_model_id != current_model_id:
-                    logger.debug(
-                        'Vosk - Switching model',
-                        extra={
-                            'old_model_id': current_model_id,
-                            'new_model_id': requested_model_id,
-                        },
-                    )
-                    current_model_id = requested_model_id
-                    model_dir = Path(str(model_path_for(current_model_id)))
-                    if not model_dir.exists():
-                        logger.warning(
-                            'Vosk - Requested model not on disk, staying on '
-                            'previous model',
-                            extra={'model_id': current_model_id},
-                        )
-                    else:
-                        model = Model(model_path=model_dir.resolve().as_posix())
-                        recognizer = KaldiRecognizer(
-                            model,
-                            SPEECH_RECOGNITION_FRAME_RATE,
-                            *([json.dumps(phrases)] if phrases else []),
-                        )
-                        continue
-
-                if (_phrases := self._phrases) != phrases:
-                    phrases = _phrases
-                    logger.debug(
-                        'Vosk - Updating phrases',
-                        extra={
-                            'new_phrases': phrases,
-                        },
-                    )
-                    if IS_RPI:
-                        recognizer.Reset()
-                        recognizer.SetGrammar(json.dumps(phrases))
-                    else:
-                        recognizer = KaldiRecognizer(
-                            model,
-                            SPEECH_RECOGNITION_FRAME_RATE,
-                            *([json.dumps(phrases)] if phrases else []),
-                        )
 
     @property
     def _phrases(self) -> tuple[str, ...] | None:

--- a/ubo_app/services/090-speech-recognition/vosk_engine.py
+++ b/ubo_app/services/090-speech-recognition/vosk_engine.py
@@ -36,23 +36,48 @@ def _read_selected_model(selected_model: str) -> str:
     return selected_model or DEFAULT_VOSK_MODEL_ID
 
 
+# Minimum gap between attempts to (re)load a not-yet-ready model. ``_run``
+# reconciles before every ~50ms mic chunk; without this throttle a model that
+# is missing or mid-extraction would be retried (and logged) ~20 times/second.
+_MODEL_RETRY_INTERVAL_SECONDS = 1.0
+
+
 class _RecognizerState(NamedTuple):
     """The loaded Vosk model/recognizer and what they were built for."""
 
     model: Model | None
     recognizer: KaldiRecognizer | None
-    model_id: str | None
+    # The model id actually loaded into ``recognizer``. Only advances on a
+    # successful load, so a selected-but-not-ready model keeps being retried
+    # instead of being abandoned while the previous recognizer lingers.
+    loaded_model_id: str | None
     phrases: tuple[str, ...] | None
+    # Loop time before which a failed (re)load must not be re-attempted.
+    retry_at: float
 
 
 def _load_model(model_id: str) -> Model | None:
-    """Load the Vosk model if it's on disk, else None (not downloaded yet)."""
+    """Load the Vosk model if it's on disk and valid, else None (retry later).
+
+    Returns None — never raises — when the model isn't ready: the directory may
+    not exist yet, or it may exist but be mid-extraction (``Model()`` then
+    raises "Failed to create a model"). The caller keeps the engine alive and
+    retries on the next audio chunk, so a just-downloaded model loads cleanly
+    once extraction finishes instead of crashing the recognition loop.
+    """
     from vosk import Model
 
     model_dir = Path(str(model_path_for(model_id)))
     if not model_dir.exists():
         return None
-    return Model(model_path=model_dir.resolve().as_posix())
+    try:
+        return Model(model_path=model_dir.resolve().as_posix())
+    except Exception as exception:  # noqa: BLE001
+        logger.warning(
+            'Vosk - Could not load model yet (incomplete download?); will retry',
+            extra={'model_id': model_id, 'error': str(exception)},
+        )
+        return None
 
 
 def _make_recognizer(
@@ -83,6 +108,26 @@ class VoskEngine(
 
         super().__init__(label='Vosk')
 
+    @override
+    def _checked_run(self) -> bool:
+        """Run the wake-word engine even when the model isn't downloaded yet.
+
+        The base ``NeedsSetupMixin._checked_run`` blocks the engine (returns
+        without starting ``_run``) while ``is_setup`` is False, and only the
+        download flow's ``decide_running_state`` ever restarts it — a fragile
+        path that leaves recognition dead until an app restart. That gate is a
+        regression from unifying this engine with the assistant's NeedsSetup
+        lifecycle (commit b0fb29f3, v1.7); before it, the speech-recognition
+        Vosk engine ran its own lifecycle and started at boot.
+
+        Unlike credential-based engines, the Vosk wake-word engine is safe to
+        run without its model: ``_run``/``_reconcile`` keep the loop alive,
+        drop audio while the model is missing, and load it the moment it's
+        downloaded — so the engine started at boot self-heals on the next audio
+        chunk with no restart.
+        """
+        return self._original_run()
+
     async def _reconcile(self, state: _RecognizerState) -> _RecognizerState:
         """Reconcile the recognizer with the selected model and phrases.
 
@@ -99,37 +144,51 @@ class VoskEngine(
             model = state.model
             recognizer = state.recognizer
 
-            if requested_model_id != state.model_id or recognizer is None:
-                model_changed = requested_model_id != state.model_id
+            if requested_model_id != state.loaded_model_id:
+                # The selection differs from what's loaded (changed, or never
+                # loaded). Attempt a load, but no more than once per
+                # ``_MODEL_RETRY_INTERVAL_SECONDS`` so a missing / mid-extraction
+                # model doesn't get hammered (and logged) on every mic chunk.
+                now = get_event_loop().time()
+                if now < state.retry_at:
+                    return state
                 new_model = _load_model(requested_model_id)
                 if new_model is not None:
                     logger.debug(
                         'Vosk - Loaded model',
                         extra={'model_id': requested_model_id},
                     )
+                    # ``loaded_model_id`` advances only here, on success.
                     return _RecognizerState(
                         new_model,
                         _make_recognizer(new_model, phrases),
                         requested_model_id,
                         phrases,
+                        0.0,
                     )
+                # Not ready yet. Keep the current recognizer (if any) and the
+                # current ``loaded_model_id`` so the requested model is retried;
+                # back off until the next interval.
                 if recognizer is not None:
-                    # Switched to a not-yet-downloaded model; keep the working
-                    # one rather than going silent.
                     logger.warning(
-                        'Vosk - Requested model not on disk, staying on '
-                        'previous model',
+                        'Vosk - Requested model not ready; staying on previous '
+                        'model',
                         extra={'model_id': requested_model_id},
                     )
-                elif model_changed:
+                else:
                     logger.debug(
-                        'Vosk - Selected model not on disk yet; waiting for '
-                        'download',
+                        'Vosk - Selected model not ready; waiting',
                         extra={'model_id': requested_model_id},
                     )
-                return state._replace(model_id=requested_model_id)
+                return state._replace(
+                    retry_at=now + _MODEL_RETRY_INTERVAL_SECONDS,
+                )
 
-            if phrases != state.phrases and model is not None:
+            if (
+                phrases != state.phrases
+                and model is not None
+                and recognizer is not None
+            ):
                 logger.debug('Vosk - Updating phrases', extra={'new_phrases': phrases})
                 if IS_RPI:
                     recognizer.Reset()
@@ -159,8 +218,9 @@ class VoskEngine(
         state = _RecognizerState(
             model=None,
             recognizer=None,
-            model_id=None,
+            loaded_model_id=None,
             phrases=None,
+            retry_at=0.0,
         )
 
         while self.should_be_running():


### PR DESCRIPTION
This pull request introduces regression tests and fixes for lazy-loading behavior in both the Vosk speech recognition and Piper TTS engines, ensuring they handle first-time setup and missing models gracefully. It also improves logging and test coverage for related code paths. The most important changes are summarized below.

---

**Piper TTS Lazy-Load and Regression Handling:**

* Added regression tests (`test_piper_tts.py`) to ensure `PiperTTSService` constructs and remains selectable even if the voice model is not yet downloaded, and that it loads the model lazily once available.
* Refactored `PiperTTSService` to not fail construction if the model file is missing; the service now uses a placeholder sample rate and loads the model only when it becomes available. [[1]](diffhunk://#diff-cb0c3f7b83f5f9a107237b22e56943da188ebae18c6fd4483bcd2de3eb7fc112R86-R101) [[2]](diffhunk://#diff-cb0c3f7b83f5f9a107237b22e56943da188ebae18c6fd4483bcd2de3eb7fc112L94-R113)
* Updated `synthesize` and `run_tts` to handle the case where no voice is loaded: they now end the turn quietly and log a warning, so the user doesn't need to restart the app after the model download. [[1]](diffhunk://#diff-cb0c3f7b83f5f9a107237b22e56943da188ebae18c6fd4483bcd2de3eb7fc112R188-R195) [[2]](diffhunk://#diff-cb0c3f7b83f5f9a107237b22e56943da188ebae18c6fd4483bcd2de3eb7fc112R239-R250)
* Introduced a `_DEFAULT_SAMPLE_RATE` constant for use before the first model load.

**Vosk Engine Lazy-Load Regression Test:**

* Added a new test module (`test_vosk_engine_lazy_load.py`) that verifies the Vosk engine does not crash or get stuck if the model is missing at startup, and that it self-heals by loading the recognizer as soon as the model appears.

**Logging Improvements:**

* Enhanced debug logging in `BackgroundRunningMixin` to trace engine state transitions, task starts, and completions, aiding in diagnosing engine lifecycle issues. [[1]](diffhunk://#diff-15f276344b13c0df1271f3646e832e4b7ebc6496b5d40de633d9511805c76afdR35-R41) [[2]](diffhunk://#diff-15f276344b13c0df1271f3646e832e4b7ebc6496b5d40de633d9511805c76afdR79-R82) [[3]](diffhunk://#diff-15f276344b13c0df1271f3646e832e4b7ebc6496b5d40de633d9511805c76afdL93-R113)

**Test Coverage and Fakes for Whisker:**

* Improved the Whisker observer tests to distinguish between file and WS-server sinks, adding a `FakeWhiskerFile` and updating assertions to clarify sink selection logic. [[1]](diffhunk://#diff-6e4b6d23323c21a1e43125079327d4ad9667ca288f7346d841d6d60e0a79c31aL22-R37) [[2]](diffhunk://#diff-6e4b6d23323c21a1e43125079327d4ad9667ca288f7346d841d6d60e0a79c31aR60) [[3]](diffhunk://#diff-6e4b6d23323c21a1e43125079327d4ad9667ca288f7346d841d6d60e0a79c31aR83) [[4]](diffhunk://#diff-6e4b6d23323c21a1e43125079327d4ad9667ca288f7346d841d6d60e0a79c31aR138-R140) [[5]](diffhunk://#diff-6e4b6d23323c21a1e43125079327d4ad9667ca288f7346d841d6d60e0a79c31aL148-R166)