### PR TITLE
Docker image bundling, gRPC LAN access, CI hardening, and repo housekeeping

### DIFF
--- a/.github/workflows/integration_delivery.yml
+++ b/.github/workflows/integration_delivery.yml
@@ -513,6 +513,34 @@ jobs:
           IMAGE_SIZE=$(awk -v IMAGE_SIZE_GB=$IMAGE_SIZE_GB 'BEGIN {printf "%.0f", IMAGE_SIZE_GB * 1024 ^ 3}')
           echo "image_size=$IMAGE_SIZE" >>"$GITHUB_OUTPUT"
 
+      - name: Download Bundled Docker Images
+        run: |
+          # Daemon-less pull of the images listed in the manifest into tarballs
+          # that Packer bakes into the image and a first-boot service loads.
+          MANIFEST=scripts/packer/bundled-docker-images.txt
+          DEST=/build/docker-images
+          mkdir -p "$DEST"
+
+          apt-get update
+          apt-get install -y curl
+
+          CRANE_VERSION=v0.20.2
+          curl -fsSL \
+            "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_arm64.tar.gz" \
+            | tar -xz -C /usr/local/bin crane
+          crane version
+
+          while IFS= read -r ref || [ -n "$ref" ]; do
+            ref="${ref%%#*}"
+            ref="$(echo "$ref" | xargs)"
+            [ -z "$ref" ] && continue
+            sanitized="$(echo "$ref" | tr '/:' '__')"
+            echo "Pulling $ref -> $DEST/$sanitized.tar"
+            crane pull --platform linux/arm64 "$ref" "$DEST/$sanitized.tar"
+          done <"$MANIFEST"
+
+          ls -lh "$DEST"
+
       - name: Build Artifact
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration_delivery.yml
+++ b/.github/workflows/integration_delivery.yml
@@ -158,10 +158,39 @@ jobs:
           uv run --frozen poe proto:generate:raw
           uv run --frozen poe proto:compile:raw
 
+      # Provider secrets live in a file on the Pi runners (UBO_SECRETS_PATH),
+      # not in GitHub Secrets, so GitHub doesn't auto-mask them. Register every
+      # value with ::add-mask:: — parsed with the same dotenv reader the tests
+      # use — so any accidental print/traceback is redacted for the whole job.
+      - name: Mask provider secrets in logs
+        if: startsWith(matrix.runner, 'ubo-pod')
+        run: |
+          uv run --frozen python <<'PY'
+          import os
+          from dotenv import dotenv_values
+
+          path = os.environ.get('UBO_SECRETS_PATH')
+          values = dotenv_values(path).values() if path and os.path.exists(path) else []
+          for value in values:
+              for line in (value or '').splitlines():
+                  if line.strip():
+                      print(f'::add-mask::{line}')
+          PY
+
       - name: Run Tests
         run: |
           mkdir -p $HOME/.kivy/mods
           uv run --frozen poe test --showlocals --make-screenshots --cov=ubo_app --cov-report=xml --cov-report=html --log-level=DEBUG
+
+      # Real-credential provider round-trips run only on the Pi pods, which hold
+      # the secrets file (UBO_SECRETS_PATH); providers without keys self-skip.
+      # Invoke the service's own `test:providers` task directly — no
+      # `--showlocals`/`--log-level=DEBUG`, which would dump keys on failure.
+      - name: Run Provider E2E Tests
+        if: startsWith(matrix.runner, 'ubo-pod')
+        run: |
+          cd ubo_app/services/090-assistant/ubo-service
+          uv run poe test:providers
 
       - name: Collect Window Screenshots
         uses: actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to Ubo App
+
+Contributions following Python best practices are welcome. This guide covers
+the workflow; the [README](README.md#-contributing) has the full development
+reference (device setup, testing details, conventions).
+
+## Getting started
+
+The automated path detects your platform (macOS or Raspberry Pi/Linux),
+installs the tooling (`uv`, `buf`, `git-lfs`, `node`), and bootstraps the
+project:
+
+```bash
+git clone https://github.com/ubopod/ubo_app.git
+cd ubo_app
+./scripts/setup-dev.sh
+```
+
+Manual path:
+
+```bash
+git lfs install && git lfs pull   # snapshots are LFS-tracked
+uv sync --dev                     # on Raspberry Pi OS first: uv venv --system-site-packages
+uv run poe proto:compile:raw      # build the gRPC bindings
+uv run poe test:unit              # verify: ~285 tests in ~5s
+```
+
+Run the app locally with `HEADLESS_KIVY_DEBUG=true uv run ubo`.
+
+## Branch model
+
+- Feature branches PR into **`development`** — never straight into `main`.
+- `main` only ever receives `development`, promoted as a fast-forward.
+- Releases are annotated, GPG-signed `vX.Y.Z` tags on `main`; CI publishes
+  PyPI packages, Pi images, and the GitHub Release. See [RELEASING.md](RELEASING.md).
+- Commit messages follow conventional commits: `type(scope): subject`.
+
+## Local quality gate
+
+```bash
+uv run poe sanity
+```
+
+This is exactly what CI runs: `typecheck` (pyright) + `lint` (ruff) + `test`
+(pytest), fanned out across the five Python workspaces — the repo root plus
+`ubo_app/rpc/`, `ubo_app/services/090-assistant/ubo-service/`,
+`ubo_app/services/090-mcp/ubo-service/`, and `ubo_app/gui/`. Every error must
+be fixed; a green `sanity` locally means a green PR gate.
+
+## Proto & generated artifacts
+
+If you add, change, or remove a store action/event (or touch
+`ubo_app/rpc/proto/`):
+
+```bash
+uv run poe proto                  # regenerate proto + Python bindings
+cd ubo_app/services/090-web-ui/web-app
+npm run proto:compile && npm run build   # regenerate the web client too
+```
+
+Commit the regenerated files — CI builds against them, and a stale `dist/`
+or bindings diff means the clients and core disagree about the wire format.
+
+## Snapshot testing
+
+Store snapshots (`.jsonc`) and window snapshots (`.hash`/`.png`) live under
+`tests/**/results/` and are asserted by the integration and flow tests.
+
+- **Never hand-edit snapshot files.** Regenerate them.
+- Regenerate with the pytest flags `--override-store-snapshots`,
+  `--override-window-snapshots`, and `--make-screenshots` (for debugging
+  mismatches via `.mismatch.png`).
+- Window snapshots are DPI-sensitive: generate them **in Docker**
+  (`uv run poe build-docker-images` once, then run the `ubo-app-test` image —
+  see the README's [testing section](README.md#running-tests-on-desktop)),
+  not on macOS.
+
+## On-device development
+
+```bash
+uv run poe device:deploy:complete   # once, to set up the pod
+uv run poe device:deploy            # deploy your working tree
+uv run poe device:test              # run the test suite on the device
+```
+
+Gotcha: pip-based deploys can leave stale `~NN-*` shadow directories next to
+the real `0NN-*` service directories under `services/` — if the device runs
+old code after a deploy, remove the `~*` directories and restart the app.
+
+## Using Claude Code
+
+The project ships curated agents, skills, and slash commands in a separate
+repo, [ubopod/ubo-claude](https://github.com/ubopod/ubo-claude), designed to
+be cloned **as** your `.claude/` directory:
+
+```bash
+git clone git@github.com:ubopod/ubo-claude.git .claude
+ln -s .claude/CLAUDE.md CLAUDE.md   # Windows: copy instead
+```
+
+Both paths are gitignored here. Notes:
+
+- **Review `.claude/settings.json` and `.claude/hooks/` before cloning** — it
+  enables plugins and hooks in your sessions (all fail-safe/warn-only).
+- `.claude/` is its own git repo: improvements to agents/skills go to
+  ubo-claude PRs, not ubo-app.
+- Start with the `/onboard` skill, and run `/pr-preflight` before opening a PR.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ at the moment.
 
 Contributions following Python best practices are welcome.
 
+> **New contributor?** Start with [CONTRIBUTING.md](CONTRIBUTING.md) — it walks
+> through the branch model, the local quality gate (`uv run poe sanity`), and
+> the optional [ubo-claude](https://github.com/ubopod/ubo-claude) Claude Code
+> tooling (specialized agents, `/onboard`, `/pr-preflight`).
+
 ### ℹ️️ Conventions
 
 - Use `UBO_` prefix for environment variables.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,14 @@ name = "ubo-app"
 dynamic = ["version"]
 description = "Ubo main app, running on device initialization. A platform for running other apps."
 license = "Apache-2.0"
-authors = [{ name = "Sassan Haradji", email = "me@sassanh.com" }]
-maintainers = [{ name = "Sassan Haradji", email = "me@sassanh.com" }]
+authors = [
+  { name = "Mehrdad M", email = "mehrdad@getubo.com" },
+  { name = "Sassan Haradji", email = "me@sassanh.com" },
+]
+maintainers = [
+  { name = "Mehrdad M", email = "mehrdad@getubo.com" },
+  { name = "Sassan Haradji", email = "me@sassanh.com" },
+]
 readme = "README.md"
 requires-python = ">=3.11, <3.12"
 keywords = ['ubo', 'ubo-pod', 'raspberry pi', 'rpi', 'home assistance']

--- a/scripts/packer/bundled-docker-images.txt
+++ b/scripts/packer/bundled-docker-images.txt
@@ -1,0 +1,8 @@
+# Docker images baked into the generated device image, loaded on first boot.
+# One full image reference per line (must include registry + tag, arm64-capable).
+# Blank lines and lines starting with '#' are ignored.
+#
+# Adding a container here is the only change needed to bundle it. Keep each ref
+# in sync with its definition under ubo_app/services/080-docker/apps/ when the
+# tag bumps.
+docker.io/thegrandpkizzle/envoy:1.26.1

--- a/scripts/packer/image.pkr.hcl
+++ b/scripts/packer/image.pkr.hcl
@@ -73,6 +73,25 @@ build {
     destination = "/wheels"
   }
 
+  # Docker image tarballs downloaded by the CI workflow (empty dir if none),
+  # plus the first-boot loader that imports them once dockerd is running.
+  # Copied to a top-level dir (like /wheels) and moved into place in the shell
+  # provisioner, which creates the nested parent.
+  provisioner "file" {
+    source      = "/build/docker-images"
+    destination = "/bundled-docker-images"
+  }
+
+  provisioner "file" {
+    source      = "scripts/packer/load-bundled-docker-images.sh"
+    destination = "/tmp/load-bundled-docker-images.sh"
+  }
+
+  provisioner "file" {
+    source      = "scripts/packer/load-bundled-docker-images.service"
+    destination = "/tmp/load-bundled-docker-images.service"
+  }
+
   provisioner "shell" {
     inline = [
       "chmod +x /install.sh",
@@ -81,6 +100,13 @@ build {
       "rm -f /etc/xdg/autostart/piwiz.desktop",
       "/install.sh --in-packer --wheels-directory=/wheels --target-version=${var.ubo_app_version}",
       "rm -rf /install.sh /wheels/",
+      "mkdir -p /var/lib/ubo",
+      "rm -rf /var/lib/ubo/bundled-docker-images",
+      "mv /bundled-docker-images /var/lib/ubo/bundled-docker-images",
+      "install -D -m 0755 /tmp/load-bundled-docker-images.sh /usr/local/lib/ubo/load-bundled-docker-images.sh",
+      "install -D -m 0644 /tmp/load-bundled-docker-images.service /etc/systemd/system/load-bundled-docker-images.service",
+      "rm -f /tmp/load-bundled-docker-images.sh /tmp/load-bundled-docker-images.service",
+      "systemctl enable load-bundled-docker-images.service || true",
       "/usr/bin/env systemctl disable userconfig || true",
       "apt-get clean -y",
       "echo DF; df -h"

--- a/scripts/packer/load-bundled-docker-images.service
+++ b/scripts/packer/load-bundled-docker-images.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Load Docker images bundled into the ubo image on first boot
+After=docker.service
+Requires=docker.service
+Wants=network-online.target
+# Run before the display manager so the autologin session — and the ubo-app
+# user service it launches — only start once the bundled images are loaded.
+# Otherwise ubo-app's first Docker status check could race the load and mark a
+# bundled image NOT_AVAILABLE (the event monitor reacts to pull/delete, not
+# load, so it would not self-correct until the next check).
+Before=display-manager.service lightdm.service
+ConditionPathExistsGlob=/var/lib/ubo/bundled-docker-images/*.tar
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/lib/ubo/load-bundled-docker-images.sh
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/packer/load-bundled-docker-images.sh
+++ b/scripts/packer/load-bundled-docker-images.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# First-boot loader for Docker images baked into the device image.
+#
+# The CI image build (scripts/packer) downloads selected images to tarballs
+# under BUNDLE_DIR. The Docker daemon is not running during the QEMU chroot
+# build, so the tarballs are loaded here on first boot — once dockerd is up —
+# and then removed. The accompanying systemd unit disables itself afterwards.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+BUNDLE_DIR="/var/lib/ubo/bundled-docker-images"
+
+shopt -s nullglob
+tarballs=("$BUNDLE_DIR"/*.tar)
+
+if [ ${#tarballs[@]} -eq 0 ]; then
+  echo "No bundled Docker image tarballs in $BUNDLE_DIR; nothing to load."
+else
+  for tarball in "${tarballs[@]}"; do
+    echo "Loading bundled Docker image from $tarball..."
+    docker load -i "$tarball"
+    rm -f "$tarball"
+    echo "Loaded and removed $tarball."
+  done
+fi
+
+# Tidy up: drop the (now empty) bundle dir and disable this one-shot so it
+# never runs again.
+rmdir "$BUNDLE_DIR" 2>/dev/null || true
+systemctl disable load-bundled-docker-images.service || true

--- a/tests/integration/results/test_core/app_runs_and_exits/store-desktop-000.jsonc
+++ b/tests/integration/results/test_core/app_runs_and_exits/store-desktop-000.jsonc
@@ -78,6 +78,7 @@
   "settings": {
     "_type": "SettingsState",
     "beta_versions": false,
+    "grpc_remote_access": false,
     "pdb_signal": false,
     "services": {},
     "services_status": "loading",

--- a/tests/integration/results/test_core/app_runs_and_exits/store-rpi-000.jsonc
+++ b/tests/integration/results/test_core/app_runs_and_exits/store-rpi-000.jsonc
@@ -78,6 +78,7 @@
   "settings": {
     "_type": "SettingsState",
     "beta_versions": false,
+    "grpc_remote_access": false,
     "pdb_signal": false,
     "services": {},
     "services_status": "loading",

--- a/tests/integration/results/test_services/all_services_register/store-desktop-000.jsonc
+++ b/tests/integration/results/test_services/all_services_register/store-desktop-000.jsonc
@@ -989,6 +989,7 @@
   "settings": {
     "_type": "SettingsState",
     "beta_versions": false,
+    "grpc_remote_access": false,
     "pdb_signal": false,
     "services": {
       "assistant": {

--- a/tests/integration/results/test_services/all_services_register/store-rpi-000.jsonc
+++ b/tests/integration/results/test_services/all_services_register/store-rpi-000.jsonc
@@ -996,6 +996,7 @@
   "settings": {
     "_type": "SettingsState",
     "beta_versions": false,
+    "grpc_remote_access": false,
     "pdb_signal": false,
     "services": {
       "assistant": {

--- a/tests/store/test_docker_envoy_app.py
+++ b/tests/store/test_docker_envoy_app.py
@@ -123,3 +123,42 @@ def test_envoy_entry_uses_networking_category_and_proxy_label() -> None:
 
     assert envoy.ENTRY.label == 'Envoy proxy'
     assert envoy.ENTRY.category == 'Networking'
+
+
+async def test_prepare_envoy_includes_native_listener_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When gRPC Access is on, Envoy renders the native-gRPC TCP listener."""
+    envoy = _import_envoy()
+    config_path = tmp_path / 'envoy.yaml'
+    monkeypatch.setattr(envoy, 'ENVOY_CONFIG_PATH', config_path)
+    monkeypatch.setattr(envoy, '_grpc_remote_access', lambda: True)
+
+    assert await envoy.prepare_envoy()
+
+    config = config_path.read_text()
+    assert 'name: grpc_native_listener' in config
+    assert 'port_value: 50053' in config
+    assert 'tcp_proxy' in config
+    # Forwards to the existing core-gRPC cluster, untouched grpc-web listener.
+    assert 'cluster: grpc_service_cluster' in config
+
+
+async def test_prepare_envoy_omits_native_listener_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When gRPC Access is off, the native listener is absent."""
+    envoy = _import_envoy()
+    config_path = tmp_path / 'envoy.yaml'
+    monkeypatch.setattr(envoy, 'ENVOY_CONFIG_PATH', config_path)
+    monkeypatch.setattr(envoy, '_grpc_remote_access', lambda: False)
+
+    assert await envoy.prepare_envoy()
+
+    config = config_path.read_text()
+    assert 'grpc_native_listener' not in config
+    assert 'port_value: 50053' not in config
+    # The grpc-web listener is still present regardless.
+    assert 'port_value: 50052' in config

--- a/tests/store/test_settings_grpc_access.py
+++ b/tests/store/test_settings_grpc_access.py
@@ -1,0 +1,69 @@
+"""Tests for the Settings "gRPC Access" toggle reducer behavior."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from redux import CompleteReducerResult, InitAction
+
+from ubo_app.store.services.notifications import NotificationsAddAction
+from ubo_app.store.settings.reducer import reducer
+from ubo_app.store.settings.types import (
+    SettingsState,
+    SettingsToggleGrpcRemoteAccessAction,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _isolated_persistent_store(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep SettingsState's persistent-store reads off the real file."""
+    store_path = tmp_path / 'state.json'
+    monkeypatch.setattr('ubo_app.constants.PERSISTENT_STORE_PATH', store_path)
+    monkeypatch.setattr(
+        'ubo_app.utils.persistent_store.PERSISTENT_STORE_PATH',
+        store_path,
+    )
+
+
+def _warnings(result: CompleteReducerResult) -> list[NotificationsAddAction]:
+    return [
+        action
+        for action in (result.actions or [])
+        if isinstance(action, NotificationsAddAction)
+    ]
+
+
+def test_toggle_on_flips_flag_and_warns() -> None:
+    """Enabling flips the flag and emits exactly one security warning."""
+    initial = reducer(None, InitAction())
+    assert isinstance(initial, SettingsState)
+    assert initial.grpc_remote_access is False
+
+    result = reducer(initial, SettingsToggleGrpcRemoteAccessAction())
+
+    assert isinstance(result, CompleteReducerResult)
+    assert result.state.grpc_remote_access is True
+    warnings = _warnings(result)
+    assert len(warnings) == 1
+    assert warnings[0].notification.id == 'grpc-access-warning'
+
+
+def test_toggle_off_flips_flag_without_warning() -> None:
+    """Disabling flips the flag back and emits no notification."""
+    initial = reducer(None, InitAction())
+    assert isinstance(initial, SettingsState)
+    enabled = reducer(initial, SettingsToggleGrpcRemoteAccessAction())
+    assert isinstance(enabled, CompleteReducerResult)
+
+    result = reducer(enabled.state, SettingsToggleGrpcRemoteAccessAction())
+
+    assert isinstance(result, CompleteReducerResult)
+    assert result.state.grpc_remote_access is False
+    assert _warnings(result) == []

--- a/ubo_app/constants/__init__.py
+++ b/ubo_app/constants/__init__.py
@@ -43,6 +43,13 @@ GRPC_LISTEN_PORT = int(os.environ.get('UBO_GRPC_LISTEN_PORT', '50051'))
 GRPC_ENVOY_LISTEN_ADDRESS = os.environ.get('UBO_GRPC_ENVOY_LISTEN_ADDRESS', '0.0.0.0')  # noqa: S104
 GRPC_ENVOY_LISTEN_PORT = int(os.environ.get('UBO_GRPC_ENVOY_LISTEN_PORT', '50052'))
 
+# Port of the Envoy raw TCP-proxy listener that forwards native gRPC traffic to
+# the loopback-only core server, exposing it to the LAN when the user enables the
+# "gRPC Access" setting. See ubo_app/services/080-docker/apps/envoy.py.
+GRPC_NATIVE_PROXY_LISTEN_PORT = int(
+    os.environ.get('UBO_GRPC_NATIVE_PROXY_LISTEN_PORT', '50053'),
+)
+
 # Most of these should be changed in ubo-app and ubo-system-manager simultaneously to
 # avoid breaking the system.
 # TODO(sassanh): Make above comment visible to the end user when a change # noqa: FIX002

--- a/ubo_app/gui/pyproject.toml
+++ b/ubo_app/gui/pyproject.toml
@@ -3,8 +3,14 @@ name = "ubo-gui-client"
 dynamic = ["version"]
 description = "Kivy GUI client for Ubo App - communicates via gRPC"
 license = "Apache-2.0"
-authors = [{ name = "Sassan Haradji", email = "me@sassanh.com" }]
-maintainers = [{ name = "Sassan Haradji", email = "me@sassanh.com" }]
+authors = [
+  { name = "Mehrdad M", email = "mehrdad@getubo.com" },
+  { name = "Sassan Haradji", email = "me@sassanh.com" },
+]
+maintainers = [
+  { name = "Mehrdad M", email = "mehrdad@getubo.com" },
+  { name = "Sassan Haradji", email = "me@sassanh.com" },
+]
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
 keywords = ["ubo", "gui", "kivy", "grpc"]

--- a/ubo_app/rpc/_class_registry.py
+++ b/ubo_app/rpc/_class_registry.py
@@ -494,6 +494,7 @@ CLASS_REGISTRY: dict[str, str] = {
     'SettingsStopServiceAction': 'ubo_app.store.settings.types',
     'SettingsStopServiceEvent': 'ubo_app.store.settings.types',
     'SettingsToggleBetaVersionsAction': 'ubo_app.store.settings.types',
+    'SettingsToggleGrpcRemoteAccessAction': 'ubo_app.store.settings.types',
     'SettingsTogglePdbSignalAction': 'ubo_app.store.settings.types',
     'SettingsToggleVisualDebugAction': 'ubo_app.store.settings.types',
     'SilenceTimeoutStopReason': 'ubo_app.store.services.assistant',

--- a/ubo_app/rpc/pyproject.toml
+++ b/ubo_app/rpc/pyproject.toml
@@ -3,8 +3,14 @@ name = "ubo-app-raw-bindings"
 dynamic = ["version"]
 description = "Raw bindings for UBO App."
 license = "Apache-2.0"
-authors = [{ name = "Sassan Haradji", email = "me@sassanh.com" }]
-maintainers = [{ name = "Sassan Haradji", email = "me@sassanh.com" }]
+authors = [
+  { name = "Mehrdad M", email = "mehrdad@getubo.com" },
+  { name = "Sassan Haradji", email = "me@sassanh.com" },
+]
+maintainers = [
+  { name = "Mehrdad M", email = "mehrdad@getubo.com" },
+  { name = "Sassan Haradji", email = "me@sassanh.com" },
+]
 readme = "README.md"
 requires-python = ">=3.11, <3.12"
 keywords = [

--- a/ubo_app/services/080-docker/apps/envoy.py
+++ b/ubo_app/services/080-docker/apps/envoy.py
@@ -10,8 +10,10 @@ from ubo_app.constants import (
     CONFIG_PATH,
     GRPC_ENVOY_LISTEN_PORT,
     GRPC_LISTEN_PORT,
+    GRPC_NATIVE_PROXY_LISTEN_PORT,
     WEB_UI_LISTEN_PORT,
 )
+from ubo_app.store.main import store
 from ubo_app.utils import IS_RPI
 
 ENVOY_TEMPLATE_PATH = Path(__file__).parent.parent / 'assets' / 'envoy.yaml.tmpl'
@@ -24,17 +26,36 @@ ENVOY_TEMPLATE_PATH = Path(__file__).parent.parent / 'assets' / 'envoy.yaml.tmpl
 # across versions and untouched by that chmod, matching how every other Docker
 # app (Hermes, Home Assistant, Node-RED) stores its runtime config.
 ENVOY_CONFIG_PATH = CONFIG_PATH / 'envoy' / 'envoy.yaml'
+# Raw TCP-proxy listener that forwards native gRPC traffic to the loopback-only
+# core server. Rendered into the config only while the "gRPC Access" setting is
+# on, exposing the native API on the LAN at 0.0.0.0:GRPC_NATIVE_PROXY_LISTEN_PORT.
+NATIVE_LISTENER_TEMPLATE_PATH = (
+    Path(__file__).parent.parent / 'assets' / 'envoy-native-listener.yaml.tmpl'
+)
+
+
+@store.with_state(lambda state: state.settings.grpc_remote_access)
+def _grpc_remote_access(grpc_remote_access: bool) -> bool:  # noqa: FBT001
+    return grpc_remote_access
 
 
 async def prepare_envoy() -> bool:
     """Prepare Envoy for gRPC."""
     server_host = '127.0.0.1' if IS_RPI else 'host.docker.internal'
+    native_listener = (
+        Template(NATIVE_LISTENER_TEMPLATE_PATH.read_text()).substitute(
+            GRPC_NATIVE_PROXY_LISTEN_PORT=f'{GRPC_NATIVE_PROXY_LISTEN_PORT}',
+        )
+        if _grpc_remote_access()
+        else ''
+    )
     rendered = Template(ENVOY_TEMPLATE_PATH.read_text()).substitute(
         GRPC_ENVOY_LISTEN_PORT=f'{GRPC_ENVOY_LISTEN_PORT}',
         GRPC_LISTEN_PORT=f'{GRPC_LISTEN_PORT}',
         GRPC_SERVER_HOST=server_host,
         WEB_UI_LISTEN_PORT=f'{WEB_UI_LISTEN_PORT}',
         WEB_UI_SERVER_HOST=server_host,
+        GRPC_NATIVE_LISTENER=native_listener,
     )
     ENVOY_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     ENVOY_CONFIG_PATH.write_text(rendered)
@@ -60,6 +81,7 @@ ENTRY = ContainerEntry(
     if IS_RPI
     else {
         f'{GRPC_ENVOY_LISTEN_PORT}/tcp': GRPC_ENVOY_LISTEN_PORT,
+        f'{GRPC_NATIVE_PROXY_LISTEN_PORT}/tcp': GRPC_NATIVE_PROXY_LISTEN_PORT,
     },
     volumes=[
         f'{ENVOY_CONFIG_PATH}:/envoy.yaml',

--- a/ubo_app/services/080-docker/assets/envoy-native-listener.yaml.tmpl
+++ b/ubo_app/services/080-docker/assets/envoy-native-listener.yaml.tmpl
@@ -1,0 +1,12 @@
+    - name: grpc_native_listener
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: $GRPC_NATIVE_PROXY_LISTEN_PORT
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.tcp_proxy
+              typed_config:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                stat_prefix: grpc_native
+                cluster: grpc_service_cluster

--- a/ubo_app/services/080-docker/assets/envoy.yaml.tmpl
+++ b/ubo_app/services/080-docker/assets/envoy.yaml.tmpl
@@ -51,6 +51,7 @@ static_resources:
                   - name: envoy.filters.http.router
                     typed_config:
                       '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+$GRPC_NATIVE_LISTENER
   clusters:
     - name: grpc_service_cluster
       connect_timeout: 5s

--- a/ubo_app/services/080-docker/docker_container.py
+++ b/ubo_app/services/080-docker/docker_container.py
@@ -320,10 +320,14 @@ def update_container(*, image_id: str, container: Container) -> None:
             DockerImageSetStatusAction(
                 image=image_id,
                 status=DockerItemStatus.STARTING,
+                # Docker reports ``None`` (not ``[]``) for ports that are
+                # EXPOSEd but not published to the host, so skip empty values
+                # before iterating the binding list.
                 ports=[
-                    f'{i["HostIp"]}:{i["HostPort"]}'
-                    for i in container.ports.values()
-                    for i in i
+                    f'{binding["HostIp"]}:{binding["HostPort"]}'
+                    for bindings in container.ports.values()
+                    if bindings
+                    for binding in bindings
                 ],
                 ip=container.attrs['NetworkSettings']['Networks']['bridge']['IPAddress']
                 if container.attrs

--- a/ubo_app/services/080-docker/setup.py
+++ b/ubo_app/services/080-docker/setup.py
@@ -21,6 +21,7 @@ from apps.home_assistant import (
 )
 from docker.models.containers import Container
 from docker.models.images import Image
+from docker_app import prepare_app
 from docker_composition import (
     COMPOSITIONS_PATH,
     check_composition,
@@ -31,6 +32,7 @@ from docker_composition import (
     stop_composition,
 )
 from docker_container import (
+    find_container,
     remove_container,
     run_container,
     start_event_monitor,
@@ -41,8 +43,11 @@ from menus import docker_item_menu, setup_docker_image_dynamic_menu
 from reducer import image_reducer, reducer_id
 from redux import CombineReducerRegisterAction
 
-from ubo_app.colors import DANGER_COLOR, SUCCESS_COLOR, WARNING_COLOR
-from ubo_app.constants import DOCKER_CREDENTIALS_TEMPLATE_SECRET_ID
+from ubo_app.colors import DANGER_COLOR, INFO_COLOR, SUCCESS_COLOR, WARNING_COLOR
+from ubo_app.constants import (
+    DOCKER_CREDENTIALS_TEMPLATE_SECRET_ID,
+    GRPC_NATIVE_PROXY_LISTEN_PORT,
+)
 from ubo_app.logger import logger
 from ubo_app.store.core.constants import APPS_ROOT_CATEGORY
 from ubo_app.store.core.types import (
@@ -64,6 +69,7 @@ from ubo_app.store.input.types import (
 )
 from ubo_app.store.main import store
 from ubo_app.store.services.docker import (
+    DockerImageFetchAction,
     DockerImageFetchCompositionEvent,
     DockerImageFetchEvent,
     DockerImageRebindEvent,
@@ -97,6 +103,7 @@ from ubo_app.store.services.notifications import (
     Chime,
     Importance,
     Notification,
+    NotificationDispatchItem,
     NotificationDisplayType,
     NotificationsAddAction,
 )
@@ -202,6 +209,9 @@ def _docker_path_matcher(path: tuple[str, ...]) -> str | None:
     return None
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ubo_app.store.services.ip import IpNetworkInterface
     from ubo_app.utils.types import Subscriptions
 
 
@@ -1007,6 +1017,196 @@ def heal_home_assistant_zigbee(image_state: ImageState | None) -> None:
         and zigbee_adapter_went_missing()
     ):
         store.dispatch(DockerImageRunAction(image=HOME_ASSISTANT_COMPOSITION_ID))
+
+
+# =============================================================================
+# gRPC LAN access (Envoy native-gRPC TCP listener) reconciler
+# =============================================================================
+# Source of truth is `settings.grpc_remote_access`. When on, the Envoy proxy must
+# run with the native-gRPC TCP listener rendered into its config (see
+# apps/envoy.py); when off, that listener must be gone. This reconciler converges
+# the actual Envoy state onto the desired flag — including on boot, where the flag
+# may be persisted True and Docker's restart policy may have already brought Envoy
+# up with a stale config.
+ENVOY_IMAGE_ID = 'envoy_grpc'
+# Listener state believed rendered into the *running* Envoy (None = unknown, e.g.
+# fresh boot) and a restart-in-flight guard. Module-level containers, not globals.
+_grpc_lan_applied: list[bool | None] = [None]
+_grpc_lan_busy: list[bool] = [False]
+
+
+# Virtual / non-LAN interfaces whose addresses are useless to advertise.
+_LAN_EXCLUDE_PREFIXES = ('lo', 'docker', 'br-', 'veth', 'tun', 'tap', 'utun')
+
+
+@store.with_state(
+    lambda state: state.ip.interfaces if hasattr(state, 'ip') else None,
+)
+def _lan_ip(interfaces: Sequence[IpNetworkInterface] | None) -> str | None:
+    """Return a likely LAN IPv4 address, preferring ethernet/wireless NICs.
+
+    Skips loopback, Docker/bridge/veth and VPN/tunnel interfaces, and prefers
+    physical ethernet (``eth*``/``en*``) and wireless (``wlan*``/``wl*``) NICs
+    over anything else so the advertised address is actually reachable.
+    """
+    fallback: str | None = None
+    for interface in interfaces or []:
+        if interface.name.startswith(_LAN_EXCLUDE_PREFIXES):
+            continue
+        for ip in interface.ip_addresses:
+            if ':' in ip or ip.startswith('127.'):
+                continue
+            if interface.name.startswith(('e', 'w')):
+                return ip
+            if fallback is None:
+                fallback = ip
+    return fallback
+
+
+def _announce_grpc_reachable() -> None:
+    ip = _lan_ip()
+    address = (
+        f'{ip}:{GRPC_NATIVE_PROXY_LISTEN_PORT}'
+        if ip
+        else f':{GRPC_NATIVE_PROXY_LISTEN_PORT}'
+    )
+    store.dispatch(
+        NotificationsAddAction(
+            notification=Notification(
+                id='grpc-access-reachable',
+                title='gRPC Access',
+                content=f'gRPC API reachable on your network at {address}',
+                icon='󰒋',
+                color=INFO_COLOR,
+                display_type=NotificationDisplayType.FLASH,
+            ),
+        ),
+    )
+
+
+def _restart_envoy_container() -> None:
+    """Restart the Envoy container in place (blocking Docker I/O)."""
+    client = docker.from_env()
+    try:
+        container = find_container(client, image_path=IMAGES[ENVOY_IMAGE_ID].path)
+        if container is not None:
+            # ``restart`` starts a stopped/created container too, so this both
+            # applies a new config to a running Envoy and boots a stopped one.
+            container.restart()
+    finally:
+        client.close()
+
+
+async def _apply_envoy(*, desired: bool, restart: bool) -> None:
+    """Re-render the Envoy config for `desired`, optionally restarting it.
+
+    The config is bind-mounted and the published-port set is unchanged, so a
+    process restart (which re-reads the file) suffices — no remove/recreate.
+    `run_container` skips re-render for an existing container, so render first.
+    When `restart` is False (a stopped container while disabled) the fresh,
+    listener-free config is written and the container is left stopped, so a later
+    manual/policy start cannot bring it up with a stale listener.
+    """
+    try:
+        if not await prepare_app(IMAGES[ENVOY_IMAGE_ID]):
+            logger.error('Failed to render Envoy config for gRPC LAN access')
+            return
+        if restart:
+            await asyncio.to_thread(_restart_envoy_container)
+        _grpc_lan_applied[0] = desired
+        if desired:
+            _announce_grpc_reachable()
+    finally:
+        _grpc_lan_busy[0] = False
+
+
+_ENVOY_BUSY_STATUSES = (
+    DockerItemStatus.FETCHING,
+    DockerItemStatus.STARTING,
+    DockerItemStatus.PROCESSING,
+)
+
+
+def _prompt_envoy_needed() -> None:
+    """Offer to download and start Envoy, which the LAN listener rides on."""
+    store.dispatch(
+        NotificationsAddAction(
+            notification=Notification(
+                id='grpc-access-envoy-needed',
+                title='gRPC Access',
+                content='The Envoy proxy is needed to expose gRPC to the LAN. '
+                'Download and start it?',
+                icon='󱂇',
+                importance=Importance.MEDIUM,
+                color=WARNING_COLOR,
+                display_type=NotificationDisplayType.STICKY,
+                actions=[
+                    NotificationDispatchItem(
+                        key='download',
+                        label='Download & Start',
+                        icon='󰇚',
+                        store_action=DockerImageFetchAction(image=ENVOY_IMAGE_ID),
+                    ),
+                ],
+            ),
+        ),
+    )
+
+
+def _reconcile_grpc_lan_enabled(status: DockerItemStatus) -> None:
+    """Ensure Envoy is running with the native listener."""
+    if status == DockerItemStatus.NOT_AVAILABLE:
+        _prompt_envoy_needed()
+    elif status == DockerItemStatus.AVAILABLE:
+        # No container exists yet; run_container's create branch re-renders with
+        # the listener, so a plain run is enough.
+        _grpc_lan_applied[0] = True
+        store.dispatch(DockerImageRunAction(image=ENVOY_IMAGE_ID))
+    elif status == DockerItemStatus.CREATED:
+        # Stopped container exists; render the listener and (re)start it.
+        _grpc_lan_busy[0] = True
+        create_task(_apply_envoy(desired=True, restart=True))
+    elif status == DockerItemStatus.RUNNING:
+        if _grpc_lan_applied[0] is True:
+            _announce_grpc_reachable()
+        else:
+            _grpc_lan_busy[0] = True
+            create_task(_apply_envoy(desired=True, restart=True))
+
+
+def _reconcile_grpc_lan_disabled(status: DockerItemStatus) -> None:
+    """Ensure the listener-free config is rendered; restart only if running.
+
+    A CREATED (stopped) container is just re-rendered so a later manual/policy
+    start cannot resurrect the listener.
+    """
+    if (
+        status in (DockerItemStatus.RUNNING, DockerItemStatus.CREATED)
+        and _grpc_lan_applied[0] is not False
+    ):
+        _grpc_lan_busy[0] = True
+        create_task(
+            _apply_envoy(desired=False, restart=status == DockerItemStatus.RUNNING),
+        )
+    else:
+        _grpc_lan_applied[0] = False
+
+
+@store.autorun(
+    lambda state: (
+        state.settings.grpc_remote_access,
+        getattr(getattr(state.docker, ENVOY_IMAGE_ID, None), 'status', None),
+    ),
+)
+def _reconcile_grpc_lan(data: tuple[bool, DockerItemStatus | None]) -> None:
+    """Converge Envoy's native-gRPC listener onto `settings.grpc_remote_access`."""
+    enabled, status = data
+    if _grpc_lan_busy[0] or status is None or status in _ENVOY_BUSY_STATUSES:
+        return
+    if enabled:
+        _reconcile_grpc_lan_enabled(status)
+    else:
+        _reconcile_grpc_lan_disabled(status)
 
 
 async def init_service() -> Subscriptions:

--- a/ubo_app/services/090-assistant/ubo-service/pyproject.toml
+++ b/ubo_app/services/090-assistant/ubo-service/pyproject.toml
@@ -3,8 +3,14 @@ name = "ubo-app-assistant"
 dynamic = ["version"]
 description = "This is part of ubo-app and communicates with it over its gRPC API"
 license = "Apache-2.0"
-authors = [{ name = "Sassan Haradji", email = "me@sassanh.com" }]
-maintainers = [{ name = "Sassan Haradji", email = "me@sassanh.com" }]
+authors = [
+  { name = "Mehrdad M", email = "mehrdad@getubo.com" },
+  { name = "Sassan Haradji", email = "me@sassanh.com" },
+]
+maintainers = [
+  { name = "Mehrdad M", email = "mehrdad@getubo.com" },
+  { name = "Sassan Haradji", email = "me@sassanh.com" },
+]
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
 keywords = ['ubo', 'ubo-pod', 'ubo-service', 'pipecat', 'assistant']

--- a/ubo_app/services/090-assistant/ubo-service/tests/provider_harness.py
+++ b/ubo_app/services/090-assistant/ubo-service/tests/provider_harness.py
@@ -110,6 +110,10 @@ class FakeUboRPCClient:
         self.frames: list[Action] = []
         self._secrets = load_secrets()
 
+    def __repr__(self) -> str:
+        """Redact secrets so a ``--showlocals`` traceback can't leak keys."""
+        return f'<FakeUboRPCClient frames={len(self.frames)} secrets=***>'
+
     @property
     def event_loop(self) -> asyncio.AbstractEventLoop:
         """The running loop (the collector timestamps/creates tasks against it)."""

--- a/ubo_app/services/090-mcp/ubo-service/pyproject.toml
+++ b/ubo_app/services/090-mcp/ubo-service/pyproject.toml
@@ -3,8 +3,14 @@ name = "ubo-app-mcp-gateway"
 dynamic = ["version"]
 description = "MCP aggregating gateway for ubo-app; communicates with it over its gRPC API"
 license = "Apache-2.0"
-authors = [{ name = "Sassan Haradji", email = "me@sassanh.com" }]
-maintainers = [{ name = "Sassan Haradji", email = "me@sassanh.com" }]
+authors = [
+  { name = "Mehrdad M", email = "mehrdad@getubo.com" },
+  { name = "Sassan Haradji", email = "me@sassanh.com" },
+]
+maintainers = [
+  { name = "Mehrdad M", email = "mehrdad@getubo.com" },
+  { name = "Sassan Haradji", email = "me@sassanh.com" },
+]
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
 keywords = ['ubo', 'ubo-pod', 'ubo-service', 'mcp', 'gateway']

--- a/ubo_app/services/090-web-ui/web-app/package.json
+++ b/ubo_app/services/090-web-ui/web-app/package.json
@@ -2,7 +2,10 @@
   "name": "ubo-rpc-client-grpc-web",
   "version": "0.0.0",
   "description": "A demo gRPC client for UBO using grpc-web",
-  "author": "Sassan Haradji <me@sassanh.com>",
+  "author": "Mehrdad M <mehrdad@getubo.com>",
+  "contributors": [
+    "Sassan Haradji <me@sassanh.com>"
+  ],
   "license": "Apache-2.0",
   "readme": "README.md",
   "keywords": [

--- a/ubo_app/side_effects.py
+++ b/ubo_app/side_effects.py
@@ -205,6 +205,10 @@ def setup_side_effects() -> Subscriptions:
         'settings:beta_versions',
         lambda state: state.settings.beta_versions,
     )
+    register_persistent_store(
+        'settings:grpc_remote_access',
+        lambda state: state.settings.grpc_remote_access,
+    )
     subscriptions = [
         store.subscribe_event(PowerOffEvent, _power_off),
         store.subscribe_event(RebootEvent, _reboot),

--- a/ubo_app/store/settings/dynamic_system_menus.py
+++ b/ubo_app/store/settings/dynamic_system_menus.py
@@ -39,6 +39,7 @@ def _setup_general_settings() -> None:
     from ubo_app.store.core.action_registry import register_action
     from ubo_app.store.settings.types import (
         SettingsToggleBetaVersionsAction,
+        SettingsToggleGrpcRemoteAccessAction,
         SettingsTogglePdbSignalAction,
         SettingsToggleVisualDebugAction,
     )
@@ -52,24 +53,32 @@ def _setup_general_settings() -> None:
     def _toggle_beta() -> None:
         store.dispatch(SettingsToggleBetaVersionsAction())
 
+    def _toggle_grpc_remote_access() -> None:
+        store.dispatch(SettingsToggleGrpcRemoteAccessAction())
+
     register_action('settings:general:toggle_pdb', _toggle_pdb)
     register_action('settings:general:toggle_visual_debug', _toggle_visual_debug)
     register_action('settings:general:toggle_beta', _toggle_beta)
+    register_action(
+        'settings:general:toggle_grpc_remote_access',
+        _toggle_grpc_remote_access,
+    )
 
     @store.autorun(
         lambda state: (
             state.settings.pdb_signal,
             state.settings.visual_debug,
             state.settings.beta_versions,
+            state.settings.grpc_remote_access,
         ),
         options=AutorunOptions(default_value=None),
     )
     def _sync_general_menu(
-        data: tuple[bool, bool, bool] | None,
+        data: tuple[bool, bool, bool, bool] | None,
     ) -> None:
         if data is None:
             return
-        pdb_signal, visual_debug, beta_versions = data
+        pdb_signal, visual_debug, beta_versions, grpc_remote_access = data
 
         store.dispatch(
             UpdateDynamicMenuAction(
@@ -93,6 +102,12 @@ def _setup_general_settings() -> None:
                         label='Beta Versions',
                         icon='󰱒' if beta_versions else '󰄱',
                         action_id='settings:general:toggle_beta',
+                    ),
+                    MenuItemData(
+                        key='grpc_remote_access',
+                        label='gRPC Access',
+                        icon='󰱒' if grpc_remote_access else '󰄱',
+                        action_id='settings:general:toggle_grpc_remote_access',
                     ),
                 ),
                 placeholder='',

--- a/ubo_app/store/settings/reducer.py
+++ b/ubo_app/store/settings/reducer.py
@@ -11,7 +11,7 @@ from redux import (
     ReducerResult,
 )
 
-from ubo_app.colors import SUCCESS_COLOR
+from ubo_app.colors import SUCCESS_COLOR, WARNING_COLOR
 from ubo_app.store.services.notifications import (
     Importance,
     Notification,
@@ -36,6 +36,7 @@ from ubo_app.store.settings.types import (
     SettingsStopServiceAction,
     SettingsStopServiceEvent,
     SettingsToggleBetaVersionsAction,
+    SettingsToggleGrpcRemoteAccessAction,
     SettingsTogglePdbSignalAction,
     SettingsToggleVisualDebugAction,
 )
@@ -114,6 +115,43 @@ def reducer(
                     UpdateManagerRequestCheckAction(),
                 ]
                 if not state.beta_versions
+                else [],
+            )
+
+        case SettingsToggleGrpcRemoteAccessAction():
+            return CompleteReducerResult(
+                state=replace(
+                    state,
+                    grpc_remote_access=not state.grpc_remote_access,
+                ),
+                actions=[
+                    NotificationsAddAction(
+                        notification=Notification(
+                            id='grpc-access-warning',
+                            title='gRPC Access',
+                            content='LAN gRPC access requested. The control API is '
+                            'unsafe while exposed.',
+                            extra_information=ReadableInformation(
+                                text="You asked to expose this Ubo's gRPC control "
+                                'API to your local network (through the Envoy '
+                                'proxy, on port 50053). That API is not yet '
+                                'authenticated, so while it is exposed any device '
+                                'on the network could read state or send commands. '
+                                'Only enable this on a trusted network. You will be '
+                                'told the exact address once it is reachable; '
+                                'disable it to restrict access back to this device '
+                                'only (localhost).',
+                                picovoice_text='',
+                                piper_text='',
+                            ),
+                            icon='󰀪',
+                            importance=Importance.HIGH,
+                            color=WARNING_COLOR,
+                            display_type=NotificationDisplayType.STICKY,
+                        ),
+                    ),
+                ]
+                if not state.grpc_remote_access
                 else [],
             )
 

--- a/ubo_app/store/settings/types.py
+++ b/ubo_app/store/settings/types.py
@@ -39,6 +39,10 @@ class SettingsToggleBetaVersionsAction(SettingsAction):
     """Toggle beta versions action."""
 
 
+class SettingsToggleGrpcRemoteAccessAction(SettingsAction):
+    """Toggle gRPC remote (LAN) access action."""
+
+
 class SettingsSetServicesAction(SettingsAction):
     """Start service action."""
 
@@ -152,6 +156,12 @@ class SettingsState(Immutable):
         default_factory=lambda: read_from_persistent_store(
             'settings:beta_versions',
             default=DEBUG_BETA_VERSIONS,
+        ),
+    )
+    grpc_remote_access: bool = field(
+        default_factory=lambda: read_from_persistent_store(
+            'settings:grpc_remote_access',
+            default=False,
         ),
     )
     services: dict[str, ServiceState] = field(default_factory=dict)

--- a/ubo_app/tui/pyproject.toml
+++ b/ubo_app/tui/pyproject.toml
@@ -3,7 +3,14 @@ name = "ubo-tui"
 dynamic = ["version"]
 description = "Text User Interface client for Ubo App"
 license = "Apache-2.0"
-authors = [{ name = "Sassan Haradji", email = "me@sassanh.com" }]
+authors = [
+  { name = "Mehrdad M", email = "mehrdad@getubo.com" },
+  { name = "Sassan Haradji", email = "me@sassanh.com" },
+]
+maintainers = [
+  { name = "Mehrdad M", email = "mehrdad@getubo.com" },
+  { name = "Sassan Haradji", email = "me@sassanh.com" },
+]
 readme = "README.md"
 requires-python = ">=3.11"
 keywords = ["ubo", "tui", "terminal", "grpc"]

--- a/ubo_app/utils/error_handlers.py
+++ b/ubo_app/utils/error_handlers.py
@@ -18,13 +18,15 @@ if TYPE_CHECKING:
 
 def setup_sentry() -> None:  # pragma: no cover
     import os
+    import socket
 
     import sentry_sdk
 
     serial_number = read_serial_number()
+    hostname = socket.gethostname()
 
     if 'SENTRY_DSN' in os.environ:
-        from sentry_sdk import set_user
+        from sentry_sdk import set_tag, set_user
 
         sentry_sdk.init(
             traces_sample_rate=1.0,
@@ -32,7 +34,10 @@ def setup_sentry() -> None:  # pragma: no cover
             ignore_errors=[KeyboardInterrupt, asyncio.CancelledError],
             server_name=serial_number,
         )
-        set_user({'id': serial_number})
+        set_user({'id': serial_number, 'username': hostname})
+        # Hostname (e.g. ``ubo-r``) is easier for users to recognise than the
+        # serial number, so expose it as an indexed tag for searching/filtering.
+        set_tag('hostname', hostname)
 
 
 def get_all_thread_stacks() -> dict[str, list[str]]:


### PR DESCRIPTION
## Summary

Six independent, low-coupling changes accumulated on this branch, grouped below by theme.

### Docker image pre-bundling (CI + first boot)
- **`ci(image): pre-bundle Docker images (Envoy) into the generated image`**
  Bakes selected Docker images into the device image at build time so a freshly flashed device already has them locally — no fetch needed before first run.
  - The image is built in a QEMU aarch64 chroot with no Docker daemon, so images can't be pulled/loaded during the Packer build itself. Instead, the CI `images` job daemon-lessly pulls each ref listed in the manifest with `crane` (`--platform linux/arm64`) into tarballs under `/build/docker-images`.
  - Packer bakes those tarballs into `/var/lib/ubo/bundled-docker-images` and installs a first-boot systemd one-shot unit.
  - On first boot — after `docker.service` starts but before the display manager (so it beats the autologin `ubo-app` session) — the loader `docker load`s each tarball, deletes it, and disables itself.
  - The image list is generalized via `scripts/packer/bundled-docker-images.txt`; adding another line bundles another container. Starts with Envoy.
  - No app/runtime change is required: the app already reports a locally-present image as `AVAILABLE`.

### gRPC LAN access toggle
- **`feat(grpc): add "gRPC Access" toggle to expose core gRPC to the LAN`**
  Adds a Settings → System → General **"gRPC Access"** toggle that exposes the loopback-only core gRPC server to the local network.
  - Rather than rebinding the core server itself, adds a raw TCP-proxy listener on `0.0.0.0:50053` to the existing Envoy proxy, forwarding into the host's `127.0.0.1:50051`. The existing grpc-web listener (`:50052`) is untouched.
  - Default is off; the API is still unauthenticated, so enabling the toggle surfaces a security warning to the user.
  - New `settings.grpc_remote_access` state/action/reducer, with persistence and a menu item.
  - New Envoy native-listener template fragment, rendered by `prepare_envoy` only when the flag is on; port `50053` is published in bridge (dev) mode.
  - The `080-docker` reconciler autorun converges Envoy's running config onto the flag: prompts to download/start Envoy if it's absent (via a serializable `NotificationDispatchItem`), re-renders and restarts Envoy in place to apply a flag change, handles every `DockerItemStatus` (including `CREATED`), honors `prepare_app()` failure, keeps blocking Docker I/O off the event loop, and announces the LAN address using a likely-LAN network interface.
  - Uses stable notification ids; the reducer records user intent while the reconciler tracks actual reach.
  - Unit tests cover the toggle reducer and Envoy listener template rendering.

### CI
- **`ci: mask provider secrets and run provider E2E tests on Pi pods`**
  Masks provider secrets in CI logs and runs provider E2E tests on Pi pods (previously not covered by that pipeline).

### Docker container fixes
- **`fix(docker): skip unpublished ports and add hostname to Sentry reports`**
  - Docker reports `None` (not `[]`) for `EXPOSE`d-but-unpublished ports, which made the ports list comprehension in `update_container` raise `'NoneType' object is not iterable'`. Guarded with `if bindings` before iterating the binding list.
  - Sentry events are now also tagged with the device hostname (`socket.gethostname()`) alongside the serial number, since hostnames are easier for users to recognize. Serial number is retained as `server_name` and user id.

### Repo housekeeping
- **`docs: add CONTRIBUTING.md and point README at it`**
  Adds `CONTRIBUTING.md` summarizing the contributor workflow (setup, branch model, `poe` sanity gate, proto/web-app regen, snapshot testing, on-device dev) and documents the optional `ubo-claude` Claude Code tooling installed at `.claude/`. README links to it.
- **`chore(metadata): add Mehrdad M as primary author/maintainer`**
  Lists Mehrdad M `<mehrdad@getubo.com>` first in authors/maintainers across all `pyproject.toml` packages and as the `package.json` author, with Sassan Haradji retained as co-author/contributor.

## Test plan
- [ ] `uv run poe lint` and `uv run poe typecheck` pass
- [ ] `uv run poe test:unit` passes, including the new `tests/store/test_settings_grpc_access.py` and `tests/store/test_docker_envoy_app.py`
- [ ] On-device: toggle "gRPC Access" on and confirm Envoy publishes `:50053` and proxies to core gRPC on the LAN; toggle off and confirm the listener is removed on reconcile
- [ ] On-device: flash a fresh image and confirm the Envoy image is present (`AVAILABLE`) without a network fetch after first boot
- [ ] CI: confirm the `images` job produces the bundled tarballs and the `integration_delivery.yml` provider E2E tests run on Pi pods with secrets masked in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qre3yCPnhTQadgsd9naNaF